### PR TITLE
Automated Dependency Upgrade Pipelines

### DIFF
--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -107,13 +107,12 @@ Each framework **MUST** be independently schedulable. A failure in one framework
 
 ## Overview
 
-The solution consists of three components:
+The solution consists of four components:
 
 1. **Version detection script** (`detect_latest_versions.py`) — queries upstream sources for latest releases
 2. **Version bump script** (`bump_dependency.py`) — performs coordinated multi-file version updates
-3. **GitHub Actions workflow** (`auto-dep-upgrade.yml`) — orchestrates detection → branch → bump → dispatch post-merge CI → wait → PR/notify
-
-The workflow is branch-based: it creates a temporary branch with the version bump changes, runs the existing build infrastructure against it, and either opens a PR (on success) or cleans up and notifies (on failure).
+3. **`auto-dep-upgrade-trigger.yml`** — detects new versions, creates upgrade branch, dispatches post-merge CI. Exits immediately.
+4. **`auto-dep-upgrade-complete.yml`** — triggered automatically via `workflow_run` when post-merge CI finishes on a `deps/upgrade-*` branch; creates PR on success, notifies Slack on failure. No polling, no idle runners.
 
 ## Version Detection Script
 
@@ -171,10 +170,6 @@ NIXL appears in both the `vllm` and `sglang` optional dependency sections of `py
 
 ## Workflow
 
-**Location**: `.github/workflows/auto-dep-upgrade.yml`
-
-A single workflow handles everything: detect → branch → dispatch post-merge CI → wait → PR/notify.
-
 Validation reuses `post-merge-ci.yml` directly rather than duplicating pipeline configuration. This requires a small modification to `post-merge-ci.yml`:
 
 **Changes to `post-merge-ci.yml`:**
@@ -210,69 +205,47 @@ vllm-dev-pipeline:
     ...
 ```
 
-When dispatched on the upgrade branch via `gh workflow run post-merge-ci.yml --ref deps/upgrade-vllm-v0.18.0 -f framework=vllm`, `actions/checkout` naturally picks up the upgrade branch code with bumped versions. For NIXL upgrades, dispatch with no framework filter so all three pipelines run.
+The two upgrade workflows are connected via GitHub's `workflow_run` trigger — no polling, no idle runners:
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│  Trigger: cron (per-framework) or workflow_dispatch      │
-└────────────────────────┬────────────────────────────────┘
-                         │
-                         ▼
-              ┌─────────────────────┐
-              │   detect-release    │
-              │  (latest version?)  │
-              └────────┬────────────┘
-                       │
-              ┌────────┴────────┐
-              │ no new release  │──→ exit(0)
-              └─────────────────┘
-                       │ new release found
-                       ▼
-              ┌─────────────────────┐
-              │   prepare-branch    │
-              │  (create branch,    │
-              │   bump versions,    │
-              │   commit & push)    │
-              └────────┬────────────┘
-                       │
-                       ▼
-              ┌─────────────────────┐
-              │   dispatch          │
-              │   post-merge-ci     │
-              │   --ref <branch>    │
-              │   -f framework=X    │
-              └────────┬────────────┘
-                       │
-                       ▼
-              ┌─────────────────────┐
-              │   gh run watch      │
-              │   (wait for         │
-              │    completion)      │
-              └────────┬────────────┘
-                       │
-              ┌────────┴────────┐
-              │                 │
-         success            failure
-              │                 │
-              ▼                 ▼
-     ┌────────────┐    ┌──────────────┐
-     │ create-pr  │    │ notify-slack │
-     │ (gh pr     │    │ + cleanup    │
-     │  create)   │    │   branch     │
-     └────────────┘    └──────────────┘
+  auto-dep-upgrade-trigger.yml              post-merge-ci.yml             auto-dep-upgrade-complete.yml
+  ─────────────────────────────             ─────────────────             ────────────────────────────
+  schedule / workflow_dispatch
+           │
+           ▼
+    detect latest version
+           │
+     no update? ──→ exit
+           │
+           ▼
+    create branch + bump
+           │
+           ▼
+    gh workflow run ─────────→  runs on upgrade branch
+    post-merge-ci.yml            (full build + test)
+    --ref <branch>                       │
+           │                             │
+         exit                        completes
+                                         │
+                                         ▼
+                               workflow_run trigger ──→  check conclusion
+                               (branches: deps/upgrade-*)     │
+                                                        ┌─────┴─────┐
+                                                     success     failure
+                                                        │           │
+                                                        ▼           ▼
+                                                    create PR   Slack notify
 ```
 
-### `auto-dep-upgrade.yml` Structure
+### `auto-dep-upgrade-trigger.yml`
 
 ```yaml
-name: Auto Dependency Upgrade
+name: Auto Dependency Upgrade Trigger
 
 on:
   schedule:
-    # Tue: vllm, trtllm
-    - cron: '0 10 * * 2'
-    # Wed: sglang, nixl
-    - cron: '0 11 * * 3'
+    # Wed: all frameworks
+    - cron: '0 10 * * 3'
   workflow_dispatch:
     inputs:
       framework:
@@ -284,10 +257,8 @@ on:
 permissions:
   contents: write
   actions: write
-  pull-requests: write
 
 jobs:
-  # Map cron schedule to framework(s); workflow_dispatch uses input directly
   resolve-frameworks:
     runs-on: ubuntu-latest
     outputs:
@@ -298,15 +269,9 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo 'matrix=["${{ inputs.framework }}"]' >> $GITHUB_OUTPUT
           else
-            DAY=$(date -u +%u)  # 1=Mon, 2=Tue, ...
-            case $DAY in
-              2) echo 'matrix=["vllm","trtllm"]' ;;
-              3) echo 'matrix=["sglang","nixl"]' ;;
-              *) echo 'matrix=[]' ;;
-            esac >> $GITHUB_OUTPUT
+            echo 'matrix=["vllm","sglang","trtllm","nixl"]' >> $GITHUB_OUTPUT
           fi
 
-  # Run the full upgrade pipeline for each framework
   upgrade:
     needs: [resolve-frameworks]
     if: needs.resolve-frameworks.outputs.matrix != '[]'
@@ -318,7 +283,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # --- Detect ---
       - name: Detect latest version
         id: detect
         env:
@@ -343,14 +307,11 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      # --- Prepare branch ---
       - name: Create upgrade branch
         if: steps.detect.outputs.needs_update == 'true' && steps.check-pr.outputs.skip != 'true'
-        id: branch
         run: |
           VERSION="${{ steps.detect.outputs.latest_version }}"
           BRANCH="deps/upgrade-${{ matrix.framework }}-${VERSION}"
-          echo "branch_name=$BRANCH" >> $GITHUB_OUTPUT
 
           git checkout -b $BRANCH
           python .github/scripts/bump_dependency.py \
@@ -359,14 +320,13 @@ jobs:
           git commit -s -m "chore: bump ${{ matrix.framework }} to ${VERSION}"
           git push origin $BRANCH
 
-      # --- Validate via post-merge CI ---
-      - name: Dispatch post-merge CI
-        if: steps.branch.outputs.branch_name != ''
-        id: dispatch
+      - name: Dispatch post-merge CI on upgrade branch
+        if: steps.detect.outputs.needs_update == 'true' && steps.check-pr.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH="${{ steps.branch.outputs.branch_name }}"
+          VERSION="${{ steps.detect.outputs.latest_version }}"
+          BRANCH="deps/upgrade-${{ matrix.framework }}-${VERSION}"
 
           # For nixl, run all frameworks; otherwise filter
           FRAMEWORK_ARG=""
@@ -375,50 +335,66 @@ jobs:
           fi
 
           gh workflow run post-merge-ci.yml --ref $BRANCH $FRAMEWORK_ARG
+```
 
-          # Wait for run to appear, then capture its ID
-          sleep 15
-          RUN_ID=$(gh run list --workflow=post-merge-ci.yml \
-            --branch=$BRANCH --limit=1 \
-            --json databaseId -q '.[0].databaseId')
-          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+### `auto-dep-upgrade-complete.yml`
 
-      - name: Wait for completion
-        if: steps.dispatch.outputs.run_id != ''
-        id: wait
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+Triggered automatically by GitHub when post-merge CI finishes on an upgrade branch. No polling needed.
+
+```yaml
+name: Auto Dependency Upgrade Complete
+
+on:
+  workflow_run:
+    workflows: ["Post-Merge CI Pipeline"]
+    types: [completed]
+    branches:
+      - 'deps/upgrade-**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  handle-result:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Extract framework and version from branch
+        id: parse
         run: |
-          gh run watch ${{ steps.dispatch.outputs.run_id }} --exit-status || true
-          CONCLUSION=$(gh run view ${{ steps.dispatch.outputs.run_id }} \
-            --json conclusion -q '.conclusion')
-          echo "conclusion=$CONCLUSION" >> $GITHUB_OUTPUT
+          # deps/upgrade-vllm-v0.18.0 → framework=vllm, version=v0.18.0
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          SUFFIX="${BRANCH#deps/upgrade-}"
+          FRAMEWORK="${SUFFIX%%-*}"
+          VERSION="${SUFFIX#*-}"
+          echo "framework=$FRAMEWORK" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      # --- Create PR on success ---
       - name: Create PR
-        if: steps.wait.outputs.conclusion == 'success'
+        if: github.event.workflow_run.conclusion == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ steps.detect.outputs.latest_version }}"
-          RUN_ID="${{ steps.dispatch.outputs.run_id }}"
-
           gh pr create \
-            --head "${{ steps.branch.outputs.branch_name }}" \
-            --title "chore: bump ${{ matrix.framework }} to ${VERSION}" \
-            --label "dep-upgrade" --label "${{ matrix.framework }}" \
+            --head "${{ github.event.workflow_run.head_branch }}" \
+            --title "chore: bump ${{ steps.parse.outputs.framework }} to ${{ steps.parse.outputs.version }}" \
+            --label "dep-upgrade" \
+            --label "${{ steps.parse.outputs.framework }}" \
             --body "$(cat <<EOF
           ## Dependency Upgrade
 
-          **Framework:** ${{ matrix.framework }}
-          **Version:** ${VERSION}
-          **Validation:** [Post-merge CI run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN_ID})
+          **Framework:** ${{ steps.parse.outputs.framework }}
+          **Version:** ${{ steps.parse.outputs.version }}
+          **Validation:** [Post-merge CI run](${{ github.event.workflow_run.html_url }})
           EOF
           )"
 
-      # --- Notify + cleanup on failure ---
       - name: Notify Slack on failure
-        if: steps.wait.outputs.conclusion == 'failure'
+        if: github.event.workflow_run.conclusion == 'failure'
         uses: slackapi/slack-github-action@v2
         with:
           webhook: ${{ secrets.SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL }}
@@ -430,16 +406,9 @@ jobs:
                   type: mrkdwn
                   text: >-
                     :alert: *Dependency upgrade failed*
-                    Framework: ${{ matrix.framework }}
-                    Version: ${{ steps.detect.outputs.latest_version }}
-                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.dispatch.outputs.run_id }}|Build Logs>
-
-      - name: Cleanup branch on failure
-        if: steps.wait.outputs.conclusion == 'failure'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git push origin --delete ${{ steps.branch.outputs.branch_name }} || true
+                    Framework: ${{ steps.parse.outputs.framework }}
+                    Version: ${{ steps.parse.outputs.version }}
+                    <${{ github.event.workflow_run.html_url }}|Build Logs>
 ```
 
 ### Schedule
@@ -448,10 +417,9 @@ Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit work
 
 | Day | Frameworks | Schedule |
 |-----|-----------|----------|
-| Tuesday | vLLM, TRTLLM | 10:00 UTC |
-| Wednesday | SGLang, NIXL | 11:00 UTC |
+| Wednesday | All (vLLM, SGLang, TRTLLM, NIXL) | 10:00 UTC |
 
-All schedules are mid-week to avoid weekend/Monday noise. Each scheduled run checks all frameworks for that day sequentially. The workflow also supports `workflow_dispatch` for manual triggers when someone wants to upgrade a specific framework outside of the regular cadence.
+Single mid-week schedule. All frameworks run in parallel via matrix strategy with `fail-fast: false`. The workflow also supports `workflow_dispatch` for manual triggers when someone wants to upgrade a specific framework outside of the regular cadence.
 
 ### Build and Test Configuration
 
@@ -461,7 +429,8 @@ For single-framework upgrades (vllm, sglang, trtllm), only that framework's pipe
 
 ### Permissions
 
-- `auto-dep-upgrade.yml`: `contents: write` (to push/delete branches), `actions: write` (to dispatch post-merge CI via `gh workflow run`), `pull-requests: write` (to create PRs)
+- `auto-dep-upgrade-trigger.yml`: `contents: write` (to push branches), `actions: write` (to dispatch post-merge CI)
+- `auto-dep-upgrade-complete.yml`: `contents: read`, `pull-requests: write` (to create PRs)
 
 The `GITHUB_TOKEN` is sufficient for same-repository operations.
 
@@ -479,9 +448,9 @@ Implement the full release detection and upgrade PR pipeline for all 4 framework
 **Deliverables:**
 - `.github/scripts/detect_latest_versions.py` — version detection from upstream sources
 - `.github/scripts/bump_dependency.py` — coordinated multi-file version bump
-- `.github/workflows/auto-dep-upgrade.yml` — detect, branch, bump, dispatch post-merge CI, wait, create PR/notify
+- `.github/workflows/auto-dep-upgrade-trigger.yml` — detect, branch, bump, dispatch post-merge CI
+- `.github/workflows/auto-dep-upgrade-complete.yml` — react to CI result, create PR or notify Slack
 - `.github/workflows/post-merge-ci.yml` — **modified**: add `workflow_dispatch` trigger with framework filter
-- `.github/workflows/auto-dep-upgrade-all.yml` — optional orchestrator for manual triggers
 
 **Rollout:**
 1. Scripts developed and tested locally

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -477,6 +477,10 @@ Once release tracking is proven stable, add a separate workflow that builds agai
 
 This workflow would run on a separate schedule, report pass/fail to Slack, and would NOT create PRs since `main` is a moving target.
 
+### Switch Validation to Nightly Pipeline
+
+Once the nightly CI pipeline is stable and reliable, switch the validation step from dispatching `post-merge-ci.yml` to dispatching `nightly-ci.yml` instead. The nightly pipeline runs a broader test suite (including tests not in post-merge) and would provide higher confidence in upgrade PRs.
+
 # Background
 
 ## Current Version Pinning Locations

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -207,32 +207,38 @@ vllm-dev-pipeline:
 
 The two upgrade workflows are connected via GitHub's `workflow_run` trigger — no polling, no idle runners:
 
-```mermaid
-flowchart LR
-    subgraph trigger["auto-dep-upgrade-trigger.yml"]
-        direction TB
-        A[Schedule / dispatch] --> B[Detect latest version]
-        B --> C{New release?}
-        C -- No --> D[Exit]
-        C -- Yes --> E{PR exists?}
-        E -- Yes --> D
-        E -- No --> F[Create branch + bump]
-    end
+```
+auto-dep-upgrade-          post-merge-              auto-dep-upgrade-
+trigger.yml                ci.yml                   complete.yml
+──────────────────         ──────────────           ──────────────────
 
-    subgraph postmerge["post-merge-ci.yml"]
-        direction TB
-        H[Build + test\non upgrade branch]
-    end
-
-    subgraph complete["auto-dep-upgrade-complete.yml"]
-        direction TB
-        J{Conclusion?}
-        J -- success --> K[Create PR]
-        J -- failure --> L[Slack notify]
-    end
-
-    F -- "gh workflow run\n--ref branch" --> H
-    H -- "workflow_run\ntrigger" --> J
+schedule / dispatch
+        │
+        ▼
+ detect latest version
+        │
+  no update? ──→ exit
+        │
+        ▼
+  PR exists? ──→ exit
+        │
+        ▼
+ create branch + bump
+        │
+        ▼
+ gh workflow run            runs on upgrade
+ post-merge-ci  ─────────→ branch (full
+ --ref <branch>            build + test)
+        │                       │
+      exit                  completes
+                                │
+                         workflow_run ──────→ check conclusion
+                         trigger fires             │
+                                             ┌─────┴─────┐
+                                          success     failure
+                                             │           │
+                                             ▼           ▼
+                                         create PR   Slack notify
 ```
 
 ### `auto-dep-upgrade-trigger.yml`

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -72,12 +72,13 @@ The system **MUST** update version references consistently across all files wher
 | `pyproject.toml` | `vllm==X.Y.Z` | `sglang==X.Y.Z` | `tensorrt-llm==X.Y.Z` | `nixl<=X.Y.Z` |
 | `container/deps/vllm/install_vllm.sh` | `VLLM_VER` (line 15) | — | — | — |
 | `container/deps/trtllm/install_nixl.sh` | — | — | — | `NIXL_COMMIT` (line 30) |
+| `deploy/pre-deployment/nixl/build_and_deploy.sh` | — | — | — | `NIXL_VERSION` (line 9) |
 
 The system **SHOULD** flag files requiring manual review in the PR body (docs, recipes, `requirements.common.txt`, trtllm torch versions).
 
-### REQ 3 Trial Build Validation
+### REQ 3 Trial Build and Test Validation
 
-The system **MUST** run a container build for the target framework on at least one platform (amd64) and one CUDA version before creating a PR. The build **MUST** reuse the existing `build-test-distribute-flavor-matrix.yml` workflow with `build_only: true`.
+The system **MUST** run a full build and test cycle for the target framework on at least one platform (amd64) and one CUDA version before creating a PR. This **MUST** include CPU-only, single GPU, and multi-GPU tests matching the post-merge CI test markers. The system **MUST** reuse the existing `build-test-distribute-flavor-matrix.yml` workflow with tests enabled (NOT `build_only`).
 
 ### REQ 4 Pull Request Creation
 
@@ -86,7 +87,7 @@ On successful build, the system **MUST** create a pull request with:
 - Labels: `dep-upgrade`, `{framework}`
 - Body containing: version change summary, build log link, manual review checklist
 
-If a prior open PR exists for the same framework, the system **SHOULD** close it and create a fresh one.
+If a prior open PR exists for the same framework and version, the system **SHOULD** skip creating a duplicate.
 
 ### REQ 5 Failure Notification
 
@@ -164,7 +165,13 @@ NIXL appears in both the `vllm` and `sglang` optional dependency sections of `py
 
 ## Workflow
 
+The workflow is split into two phases across two workflow files. This is necessary because GitHub Actions reusable workflows (`workflow_call`) check out code from the calling workflow's ref. If a single workflow running on `main` calls the build pipeline, it would build `main`'s code — not the upgrade branch with version bumps. By dispatching phase 2 on the upgrade branch, `actions/checkout` naturally picks up the bumped versions.
+
+### Phase 1: Detect and Prepare
+
 **Location**: `.github/workflows/dep-upgrade-release.yml`
+
+Triggered by schedule or `workflow_dispatch` on `main`. Detects new versions, creates the upgrade branch, and dispatches phase 2.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -191,12 +198,42 @@ NIXL appears in both the `vllm` and `sglang` optional dependency sections of `py
                        │
                        ▼
               ┌─────────────────────┐
-              │   trial-build       │
+              │   dispatch phase 2  │
+              │  gh workflow run    │
+              │  dep-upgrade-       │
+              │  test.yml           │
+              │  --ref <branch>     │
+              └─────────────────────┘
+```
+
+### Phase 2: Build, Test, and PR
+
+**Location**: `.github/workflows/dep-upgrade-test.yml`
+
+Triggered via `workflow_dispatch` on the upgrade branch. Since it runs in the context of the upgrade branch, all `actions/checkout` calls naturally pick up the bumped version files.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Trigger: workflow_dispatch on upgrade branch            │
+│  Inputs: framework, version                              │
+└────────────────────────┬────────────────────────────────┘
+                         │
+                         ▼
+              ┌─────────────────────┐
+              │   setup             │
+              │  (resolve framework │
+              │   → CUDA versions,  │
+              │   test markers)     │
+              └────────┬────────────┘
+                       │
+                       ▼
+              ┌─────────────────────┐
+              │   build-and-test    │
               │  (build-test-       │
               │   distribute-       │
               │   flavor-matrix)    │
-              │  build_only: true   │
-              │  amd64 only         │
+              │  per framework      │
+              │  (nixl → all 3)     │
               └────────┬────────────┘
                        │
               ┌────────┴────────┐
@@ -211,6 +248,146 @@ NIXL appears in both the `vllm` and `sglang` optional dependency sections of `py
      └────────────┘    └──────────────┘
 ```
 
+**Implementation**: The `setup` job resolves framework-specific configuration because `workflow_call` inputs cannot use conditionals. For NIXL upgrades, the workflow runs all three framework pipelines (vLLM, SGLang, TRTLLM) in parallel since NIXL is a shared dependency built into each framework's container.
+
+```yaml
+# dep-upgrade-test.yml (sketch)
+name: Dependency Upgrade Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      framework:
+        description: 'Framework being upgraded'
+        required: true
+        type: choice
+        options: [vllm, sglang, trtllm, nixl]
+      version:
+        description: 'Version being upgraded to'
+        required: true
+        type: string
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      # Which framework builds to run (nixl → all three)
+      run_vllm: ${{ steps.config.outputs.run_vllm }}
+      run_sglang: ${{ steps.config.outputs.run_sglang }}
+      run_trtllm: ${{ steps.config.outputs.run_trtllm }}
+    steps:
+      - id: config
+        run: |
+          case "${{ inputs.framework }}" in
+            vllm)
+              echo "run_vllm=true"   >> $GITHUB_OUTPUT
+              echo "run_sglang=false" >> $GITHUB_OUTPUT
+              echo "run_trtllm=false" >> $GITHUB_OUTPUT
+              ;;
+            sglang)
+              echo "run_vllm=false"  >> $GITHUB_OUTPUT
+              echo "run_sglang=true" >> $GITHUB_OUTPUT
+              echo "run_trtllm=false" >> $GITHUB_OUTPUT
+              ;;
+            trtllm)
+              echo "run_vllm=false"   >> $GITHUB_OUTPUT
+              echo "run_sglang=false" >> $GITHUB_OUTPUT
+              echo "run_trtllm=true"  >> $GITHUB_OUTPUT
+              ;;
+            nixl)
+              # NIXL is built into all frameworks — validate all three
+              echo "run_vllm=true"   >> $GITHUB_OUTPUT
+              echo "run_sglang=true" >> $GITHUB_OUTPUT
+              echo "run_trtllm=true" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+  vllm-pipeline:
+    needs: [setup]
+    if: needs.setup.outputs.run_vllm == 'true'
+    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
+    with:
+      framework: vllm
+      target: runtime
+      platforms: '["amd64"]'
+      cuda_versions: '["12.9"]'
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: 180
+      copy_to_acr: false
+      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
+      single_gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1'
+      multi_gpu_test_markers: '(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4)'
+      cpu_only_test_timeout_minutes: 60
+      single_gpu_test_timeout_minutes: 60
+      multi_gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  sglang-pipeline:
+    needs: [setup]
+    if: needs.setup.outputs.run_sglang == 'true'
+    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
+    with:
+      framework: sglang
+      target: runtime
+      platforms: '["amd64"]'
+      cuda_versions: '["12.9"]'
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: 180
+      copy_to_acr: false
+      cpu_only_test_markers: '(pre_merge or post_merge) and sglang and gpu_0'
+      single_gpu_test_markers: '(pre_merge or post_merge) and sglang and gpu_1'
+      multi_gpu_test_markers: '(pre_merge or post_merge) and sglang and (gpu_2 or gpu_4)'
+      cpu_only_test_timeout_minutes: 60
+      single_gpu_test_timeout_minutes: 60
+      multi_gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  trtllm-pipeline:
+    needs: [setup]
+    if: needs.setup.outputs.run_trtllm == 'true'
+    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
+    with:
+      framework: trtllm
+      target: runtime
+      platforms: '["amd64"]'
+      cuda_versions: '["13.1"]'
+      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      build_timeout_minutes: 180
+      copy_to_acr: false
+      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
+      single_gpu_test_markers: '(pre_merge or post_merge) and trtllm and gpu_1'
+      multi_gpu_test_markers: '(pre_merge or post_merge) and trtllm and (gpu_2 or gpu_4)'
+      cpu_only_test_timeout_minutes: 60
+      single_gpu_test_timeout_minutes: 60
+      multi_gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  create-pr:
+    needs: [setup, vllm-pipeline, sglang-pipeline, trtllm-pipeline]
+    if: |
+      always() &&
+      (needs.vllm-pipeline.result == 'success' || needs.vllm-pipeline.result == 'skipped') &&
+      (needs.sglang-pipeline.result == 'success' || needs.sglang-pipeline.result == 'skipped') &&
+      (needs.trtllm-pipeline.result == 'success' || needs.trtllm-pipeline.result == 'skipped') &&
+      !contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create PR with version summary and build link
+
+  notify-failure:
+    needs: [setup, vllm-pipeline, sglang-pipeline, trtllm-pipeline]
+    if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack + cleanup branch
+        # Slack webhook + delete branch
+```
+
 ### Schedule
 
 Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit worker contention:
@@ -222,24 +399,30 @@ Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit work
 | TRTLLM | Wed 10:00 UTC | NVIDIA release cadence |
 | NIXL | Fri 10:00 UTC | Internal project |
 
-### Build Configuration Per Framework
+### Build and Test Configuration Per Framework
 
-| Framework | CUDA Version | Notes |
-|-----------|-------------|-------|
-| vLLM | `["12.9"]` | Primary CUDA version |
-| SGLang | `["12.9"]` | Primary CUDA version |
-| TRTLLM | `["13.1"]` | Only supported CUDA version |
-| NIXL | N/A | Built as part of vLLM build; trigger vLLM build for validation |
+The trial run uses the same test markers as post-merge CI but on a single platform (amd64) and primary CUDA version to balance coverage with resource cost.
+
+| Framework | CUDA Version | CPU Test Markers | Single GPU Markers | Multi GPU Markers |
+|-----------|-------------|------------------|--------------------|--------------------|
+| vLLM | `["12.9"]` | `(pre_merge or post_merge) and vllm and gpu_0` | `(pre_merge or post_merge) and vllm and gpu_1` | `(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4)` |
+| SGLang | `["12.9"]` | `(pre_merge or post_merge) and sglang and gpu_0` | `(pre_merge or post_merge) and sglang and gpu_1` | `(pre_merge or post_merge) and sglang and (gpu_2 or gpu_4)` |
+| TRTLLM | `["13.1"]` | `(pre_merge or post_merge) and trtllm and gpu_0` | `(pre_merge or post_merge) and trtllm and gpu_1` | `(pre_merge or post_merge) and trtllm and (gpu_2 or gpu_4)` |
+| NIXL | N/A | Built as part of other framework builds; triggers vLLM, SGLang, and TRTLLM build+test for validation | | |
+
+Test timeouts follow post-merge CI: 60 minutes for CPU, single GPU, and multi-GPU test tiers. Images are NOT copied to ACR (`copy_to_acr: false`) since these are trial builds.
 
 ### Permissions
 
-The workflow requires `contents: write` (to push branches) and `pull-requests: write` (to create PRs). The `GITHUB_TOKEN` is sufficient for same-repository operations.
+- **Phase 1** (`dep-upgrade-release.yml`): `contents: write` (to push branches) and `actions: write` (to dispatch phase 2 via `gh workflow run`)
+- **Phase 2** (`dep-upgrade-test.yml`): `contents: write` (to delete branch on failure) and `pull-requests: write` (to create PRs)
+
+The `GITHUB_TOKEN` is sufficient for same-repository operations.
 
 ### PR Lifecycle
 
 - Branch naming: `deps/upgrade-{framework}-{version}`
-- If an open PR with labels `[dep-upgrade, {framework}]` already exists for an older version: close the old PR, delete the old branch, then create the new one
-- If an open PR exists for the same version: skip (already in progress)
+- If an open PR already exists for the same framework and version: skip (already in progress)
 
 # Implementation Phases
 
@@ -250,7 +433,8 @@ Implement the full release detection and upgrade PR pipeline for all 4 framework
 **Deliverables:**
 - `.github/scripts/detect_latest_versions.py` — version detection from upstream sources
 - `.github/scripts/bump_dependency.py` — coordinated multi-file version bump
-- `.github/workflows/dep-upgrade-release.yml` — main upgrade workflow
+- `.github/workflows/dep-upgrade-release.yml` — phase 1: detect, branch, bump, dispatch
+- `.github/workflows/dep-upgrade-test.yml` — phase 2: build, test, PR/notify (runs on upgrade branch)
 - `.github/workflows/dep-upgrade-all.yml` — optional orchestrator for manual triggers
 
 **Rollout:**
@@ -282,7 +466,8 @@ This workflow would run on a separate schedule, report pass/fail to Slack, and w
 | Container builds | `container/context.yaml` | `vllm_ref: v0.17.1` |
 | Python packages | `pyproject.toml` | `vllm[flashinfer,runai]==0.17.1` |
 | vLLM install | `container/deps/vllm/install_vllm.sh` | `VLLM_VER="0.17.1"` |
-| NIXL install | `container/deps/trtllm/install_nixl.sh` | `NIXL_COMMIT="0.10.1"` |
+| NIXL install (container) | `container/deps/trtllm/install_nixl.sh` | `NIXL_COMMIT="0.10.1"` |
+| NIXL install (deploy) | `deploy/pre-deployment/nixl/build_and_deploy.sh` | `NIXL_VERSION="0.10.1"` |
 | Documentation | `docs/reference/support-matrix.md` | Version compatibility table |
 
 ## Current CI Build Infrastructure

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -208,36 +208,36 @@ vllm-dev-pipeline:
 The two upgrade workflows are connected via GitHub's `workflow_run` trigger — no polling, no idle runners:
 
 ```
-auto-dep-upgrade-trigger.yml           post-merge-ci.yml              auto-dep-upgrade-complete.yml
-────────────────────────────           ─────────────────              ────────────────────────────
-
-  schedule / dispatch
-          │
-          ▼
-   detect latest version
-          │
-    no update? ──→ exit
-          │
-          ▼
-    PR exists? ──→ exit
-          │
-          ▼
-   create branch + bump
-          │
-          ▼
-   gh workflow run              runs on upgrade branch
-   post-merge-ci  ──────────→  (full build + test on
-   --ref <branch>               all platforms + CUDA)
-          │                            │
-        exit                       completes
-                                       │
-                                workflow_run ──────────→  check conclusion
-                                trigger fires                   │
-                                                          ┌─────┴─────┐
-                                                       success     failure
-                                                          │           │
-                                                          ▼           ▼
-                                                      create PR   Slack notify
+auto-dep-upgrade-trigger.yml    ┊  post-merge-ci.yml           ┊  auto-dep-upgrade-complete.yml
+────────────────────────────────┊──────────────────────────────┊───────────────────────────────
+                                ┊                              ┊
+  schedule / dispatch           ┊                              ┊
+          │                     ┊                              ┊
+          ▼                     ┊                              ┊
+   detect latest version        ┊                              ┊
+          │                     ┊                              ┊
+    no update? ──→ exit         ┊                              ┊
+          │                     ┊                              ┊
+          ▼                     ┊                              ┊
+    PR exists? ──→ exit         ┊                              ┊
+          │                     ┊                              ┊
+          ▼                     ┊                              ┊
+   create branch + bump         ┊                              ┊
+          │                     ┊                              ┊
+          ▼                     ┊                              ┊
+   gh workflow run ──────────────→  runs on upgrade branch     ┊
+   --ref <branch>               ┊  (full build + test on       ┊
+          │                     ┊   all platforms + CUDA)      ┊
+        exit                    ┊         │                    ┊
+                                ┊     completes                ┊
+                                ┊         │                    ┊
+                                ┊  workflow_run trigger ────────→  check conclusion
+                                ┊                              ┊        │
+                                ┊                              ┊  ┌─────┴─────┐
+                                ┊                              ┊  success  failure
+                                ┊                              ┊     │        │
+                                ┊                              ┊     ▼        ▼
+                                ┊                              ┊  create PR  Slack notify
 ```
 
 ### `auto-dep-upgrade-trigger.yml`

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -208,37 +208,36 @@ vllm-dev-pipeline:
 The two upgrade workflows are connected via GitHub's `workflow_run` trigger — no polling, no idle runners:
 
 ```
-auto-dep-upgrade-          post-merge-              auto-dep-upgrade-
-trigger.yml                ci.yml                   complete.yml
-──────────────────         ──────────────           ──────────────────
+auto-dep-upgrade-trigger.yml           post-merge-ci.yml              auto-dep-upgrade-complete.yml
+────────────────────────────           ─────────────────              ────────────────────────────
 
-schedule / dispatch
-        │
-        ▼
- detect latest version
-        │
-  no update? ──→ exit
-        │
-        ▼
-  PR exists? ──→ exit
-        │
-        ▼
- create branch + bump
-        │
-        ▼
- gh workflow run            runs on upgrade
- post-merge-ci  ─────────→ branch (full
- --ref <branch>            build + test)
-        │                       │
-      exit                  completes
-                                │
-                         workflow_run ──────→ check conclusion
-                         trigger fires             │
-                                             ┌─────┴─────┐
-                                          success     failure
-                                             │           │
-                                             ▼           ▼
-                                         create PR   Slack notify
+  schedule / dispatch
+          │
+          ▼
+   detect latest version
+          │
+    no update? ──→ exit
+          │
+          ▼
+    PR exists? ──→ exit
+          │
+          ▼
+   create branch + bump
+          │
+          ▼
+   gh workflow run              runs on upgrade branch
+   post-merge-ci  ──────────→  (full build + test on
+   --ref <branch>               all platforms + CUDA)
+          │                            │
+        exit                       completes
+                                       │
+                                workflow_run ──────────→  check conclusion
+                                trigger fires                   │
+                                                          ┌─────┴─────┐
+                                                       success     failure
+                                                          │           │
+                                                          ▼           ▼
+                                                      create PR   Slack notify
 ```
 
 ### `auto-dep-upgrade-trigger.yml`

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -111,7 +111,7 @@ The solution consists of three components:
 
 1. **Version detection script** (`detect_latest_versions.py`) — queries upstream sources for latest releases
 2. **Version bump script** (`bump_dependency.py`) — performs coordinated multi-file version updates
-3. **GitHub Actions workflow** (`dep-upgrade-release.yml`) — orchestrates detection → branch → bump → dispatch post-merge CI → wait → PR/notify
+3. **GitHub Actions workflow** (`auto-dep-upgrade.yml`) — orchestrates detection → branch → bump → dispatch post-merge CI → wait → PR/notify
 
 The workflow is branch-based: it creates a temporary branch with the version bump changes, runs the existing build infrastructure against it, and either opens a PR (on success) or cleans up and notifies (on failure).
 
@@ -171,7 +171,7 @@ NIXL appears in both the `vllm` and `sglang` optional dependency sections of `py
 
 ## Workflow
 
-**Location**: `.github/workflows/dep-upgrade-release.yml`
+**Location**: `.github/workflows/auto-dep-upgrade.yml`
 
 A single workflow handles everything: detect → branch → dispatch post-merge CI → wait → PR/notify.
 
@@ -199,13 +199,14 @@ on:
         options: ['', vllm, sglang, trtllm]
 
 # Each framework pipeline gets a conditional:
+# github.event_name == 'push' preserves existing behavior on main/release branches
 vllm-pipeline:
-    if: inputs.framework == '' || inputs.framework == 'vllm'
+    if: github.event_name == 'push' || inputs.framework == '' || inputs.framework == 'vllm'
     ...
 
 # Dev/EFA/operator/deploy jobs skip on workflow_dispatch:
 vllm-dev-pipeline:
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name == 'push'
     ...
 ```
 
@@ -261,16 +262,196 @@ When dispatched on the upgrade branch via `gh workflow run post-merge-ci.yml --r
      └────────────┘    └──────────────┘
 ```
 
+### `auto-dep-upgrade.yml` Structure
+
+```yaml
+name: Auto Dependency Upgrade
+
+on:
+  schedule:
+    # Tue: vllm, trtllm
+    - cron: '0 10 * * 2'
+    # Wed: sglang, nixl
+    - cron: '0 11 * * 3'
+  workflow_dispatch:
+    inputs:
+      framework:
+        description: 'Framework to upgrade'
+        required: true
+        type: choice
+        options: [vllm, sglang, trtllm, nixl]
+
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
+
+jobs:
+  # Map cron schedule to framework(s); workflow_dispatch uses input directly
+  resolve-frameworks:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
+    steps:
+      - id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo 'matrix=["${{ inputs.framework }}"]' >> $GITHUB_OUTPUT
+          else
+            DAY=$(date -u +%u)  # 1=Mon, 2=Tue, ...
+            case $DAY in
+              2) echo 'matrix=["vllm","trtllm"]' ;;
+              3) echo 'matrix=["sglang","nixl"]' ;;
+              *) echo 'matrix=[]' ;;
+            esac >> $GITHUB_OUTPUT
+          fi
+
+  # Run the full upgrade pipeline for each framework
+  upgrade:
+    needs: [resolve-frameworks]
+    if: needs.resolve-frameworks.outputs.matrix != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        framework: ${{ fromJson(needs.resolve-frameworks.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # --- Detect ---
+      - name: Detect latest version
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESULT=$(python .github/scripts/detect_latest_versions.py \
+            --framework ${{ matrix.framework }})
+          echo "latest_version=$(echo $RESULT | jq -r '.latest')" >> $GITHUB_OUTPUT
+          echo "needs_update=$(echo $RESULT | jq -r '.needs_update')" >> $GITHUB_OUTPUT
+
+      - name: Check for existing PR
+        if: steps.detect.outputs.needs_update == 'true'
+        id: check-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --label "dep-upgrade" \
+            --label "${{ matrix.framework }}" --json title --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      # --- Prepare branch ---
+      - name: Create upgrade branch
+        if: steps.detect.outputs.needs_update == 'true' && steps.check-pr.outputs.skip != 'true'
+        id: branch
+        run: |
+          VERSION="${{ steps.detect.outputs.latest_version }}"
+          BRANCH="deps/upgrade-${{ matrix.framework }}-${VERSION}"
+          echo "branch_name=$BRANCH" >> $GITHUB_OUTPUT
+
+          git checkout -b $BRANCH
+          python .github/scripts/bump_dependency.py \
+            --framework ${{ matrix.framework }} --version $VERSION
+          git add -A
+          git commit -s -m "chore: bump ${{ matrix.framework }} to ${VERSION}"
+          git push origin $BRANCH
+
+      # --- Validate via post-merge CI ---
+      - name: Dispatch post-merge CI
+        if: steps.branch.outputs.branch_name != ''
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch_name }}"
+
+          # For nixl, run all frameworks; otherwise filter
+          FRAMEWORK_ARG=""
+          if [ "${{ matrix.framework }}" != "nixl" ]; then
+            FRAMEWORK_ARG="-f framework=${{ matrix.framework }}"
+          fi
+
+          gh workflow run post-merge-ci.yml --ref $BRANCH $FRAMEWORK_ARG
+
+          # Wait for run to appear, then capture its ID
+          sleep 15
+          RUN_ID=$(gh run list --workflow=post-merge-ci.yml \
+            --branch=$BRANCH --limit=1 \
+            --json databaseId -q '.[0].databaseId')
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Wait for completion
+        if: steps.dispatch.outputs.run_id != ''
+        id: wait
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run watch ${{ steps.dispatch.outputs.run_id }} --exit-status || true
+          CONCLUSION=$(gh run view ${{ steps.dispatch.outputs.run_id }} \
+            --json conclusion -q '.conclusion')
+          echo "conclusion=$CONCLUSION" >> $GITHUB_OUTPUT
+
+      # --- Create PR on success ---
+      - name: Create PR
+        if: steps.wait.outputs.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.detect.outputs.latest_version }}"
+          RUN_ID="${{ steps.dispatch.outputs.run_id }}"
+
+          gh pr create \
+            --head "${{ steps.branch.outputs.branch_name }}" \
+            --title "chore: bump ${{ matrix.framework }} to ${VERSION}" \
+            --label "dep-upgrade" --label "${{ matrix.framework }}" \
+            --body "$(cat <<EOF
+          ## Dependency Upgrade
+
+          **Framework:** ${{ matrix.framework }}
+          **Version:** ${VERSION}
+          **Validation:** [Post-merge CI run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN_ID})
+          EOF
+          )"
+
+      # --- Notify + cleanup on failure ---
+      - name: Notify Slack on failure
+        if: steps.wait.outputs.conclusion == 'failure'
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: "section"
+                text:
+                  type: mrkdwn
+                  text: >-
+                    :alert: *Dependency upgrade failed*
+                    Framework: ${{ matrix.framework }}
+                    Version: ${{ steps.detect.outputs.latest_version }}
+                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.dispatch.outputs.run_id }}|Build Logs>
+
+      - name: Cleanup branch on failure
+        if: steps.wait.outputs.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin --delete ${{ steps.branch.outputs.branch_name }} || true
+```
+
 ### Schedule
 
 Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit worker contention:
 
-| Framework | Schedule | Rationale |
-|-----------|----------|-----------|
-| vLLM | Mon + Thu 10:00 UTC | High upstream velocity |
-| SGLang | Tue 10:00 UTC | Moderate velocity |
-| TRTLLM | Wed 10:00 UTC | NVIDIA release cadence |
-| NIXL | Fri 10:00 UTC | Internal project |
+| Day | Frameworks | Schedule |
+|-----|-----------|----------|
+| Tuesday | vLLM, TRTLLM | 10:00 UTC |
+| Wednesday | SGLang, NIXL | 11:00 UTC |
+
+All schedules are mid-week to avoid weekend/Monday noise. Each scheduled run checks all frameworks for that day sequentially. The workflow also supports `workflow_dispatch` for manual triggers when someone wants to upgrade a specific framework outside of the regular cadence.
 
 ### Build and Test Configuration
 
@@ -280,7 +461,7 @@ For single-framework upgrades (vllm, sglang, trtllm), only that framework's pipe
 
 ### Permissions
 
-- `dep-upgrade-release.yml`: `contents: write` (to push/delete branches), `actions: write` (to dispatch post-merge CI via `gh workflow run`), `pull-requests: write` (to create PRs)
+- `auto-dep-upgrade.yml`: `contents: write` (to push/delete branches), `actions: write` (to dispatch post-merge CI via `gh workflow run`), `pull-requests: write` (to create PRs)
 
 The `GITHUB_TOKEN` is sufficient for same-repository operations.
 
@@ -298,9 +479,9 @@ Implement the full release detection and upgrade PR pipeline for all 4 framework
 **Deliverables:**
 - `.github/scripts/detect_latest_versions.py` — version detection from upstream sources
 - `.github/scripts/bump_dependency.py` — coordinated multi-file version bump
-- `.github/workflows/dep-upgrade-release.yml` — detect, branch, bump, dispatch post-merge CI, wait, create PR/notify
+- `.github/workflows/auto-dep-upgrade.yml` — detect, branch, bump, dispatch post-merge CI, wait, create PR/notify
 - `.github/workflows/post-merge-ci.yml` — **modified**: add `workflow_dispatch` trigger with framework filter
-- `.github/workflows/dep-upgrade-all.yml` — optional orchestrator for manual triggers
+- `.github/workflows/auto-dep-upgrade-all.yml` — optional orchestrator for manual triggers
 
 **Rollout:**
 1. Scripts developed and tested locally

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -73,12 +73,18 @@ The system **MUST** update version references consistently across all files wher
 | `container/deps/vllm/install_vllm.sh` | `VLLM_VER` (line 15) | — | — | — |
 | `container/deps/trtllm/install_nixl.sh` | — | — | — | `NIXL_COMMIT` (line 30) |
 | `deploy/pre-deployment/nixl/build_and_deploy.sh` | — | — | — | `NIXL_VERSION` (line 9) |
+| `deploy/pre-deployment/nixl/README.md` | — | — | — | NIXL version references |
+| `docs/reference/support-matrix.md` | `main (ToT)` row | `main (ToT)` row | `main (ToT)` row | `main (ToT)` row |
 
-The system **SHOULD** flag files requiring manual review in the PR body (docs, recipes, `requirements.common.txt`, trtllm torch versions).
+**Files NOT auto-modified** (they track Dynamo release versions, not upstream framework versions):
+- `docs/reference/release-artifacts.md` — documents what shipped in each Dynamo release
+- Recipe YAML files — reference Dynamo release versions and minimum requirements
+- `container/deps/requirements.common.txt` — shared constraints like `transformers>=` that may require cross-framework compatibility analysis
+- trtllm `torch_version`, `pytorch_triton_ver`, etc. — tied to the NGC PyTorch base image
 
 ### REQ 3 Trial Build and Test Validation
 
-The system **MUST** run a full build and test cycle for the target framework on at least one platform (amd64) and one CUDA version before creating a PR. This **MUST** include CPU-only, single GPU, and multi-GPU tests matching the post-merge CI test markers. The system **MUST** reuse the existing `build-test-distribute-flavor-matrix.yml` workflow with tests enabled (NOT `build_only`).
+The system **MUST** run the full post-merge CI pipeline for the target framework before creating a PR. This **MUST** reuse the existing `post-merge-ci.yml` workflow directly, dispatched on the upgrade branch, to ensure the validation is identical to what runs on `main` after merge.
 
 ### REQ 4 Pull Request Creation
 
@@ -105,7 +111,7 @@ The solution consists of three components:
 
 1. **Version detection script** (`detect_latest_versions.py`) — queries upstream sources for latest releases
 2. **Version bump script** (`bump_dependency.py`) — performs coordinated multi-file version updates
-3. **GitHub Actions workflow** (`dep-upgrade-release.yml`) — orchestrates detection → branch → build → PR/notify
+3. **GitHub Actions workflow** (`dep-upgrade-release.yml`) — orchestrates detection → branch → bump → dispatch post-merge CI → wait → PR/notify
 
 The workflow is branch-based: it creates a temporary branch with the version bump changes, runs the existing build infrastructure against it, and either opens a PR (on success) or cleans up and notifies (on failure).
 
@@ -165,13 +171,45 @@ NIXL appears in both the `vllm` and `sglang` optional dependency sections of `py
 
 ## Workflow
 
-The workflow is split into two phases across two workflow files. This is necessary because GitHub Actions reusable workflows (`workflow_call`) check out code from the calling workflow's ref. If a single workflow running on `main` calls the build pipeline, it would build `main`'s code — not the upgrade branch with version bumps. By dispatching phase 2 on the upgrade branch, `actions/checkout` naturally picks up the bumped versions.
-
-### Phase 1: Detect and Prepare
-
 **Location**: `.github/workflows/dep-upgrade-release.yml`
 
-Triggered by schedule or `workflow_dispatch` on `main`. Detects new versions, creates the upgrade branch, and dispatches phase 2.
+A single workflow handles everything: detect → branch → dispatch post-merge CI → wait → PR/notify.
+
+Validation reuses `post-merge-ci.yml` directly rather than duplicating pipeline configuration. This requires a small modification to `post-merge-ci.yml`:
+
+**Changes to `post-merge-ci.yml`:**
+
+1. Add `workflow_dispatch` trigger with a `framework` filter input
+2. Add conditionals so each framework pipeline only runs when matching the filter (or when no filter is set, preserving existing behavior)
+3. Skip dev/EFA/operator/deploy jobs when triggered via `workflow_dispatch` (not relevant for dependency upgrades)
+
+```yaml
+# Addition to post-merge-ci.yml triggers
+on:
+  push:
+    branches:
+      - main
+      - 'release/*.*.*'
+  workflow_dispatch:
+    inputs:
+      framework:
+        description: 'Run only this framework pipeline (empty = all)'
+        required: false
+        type: choice
+        options: ['', vllm, sglang, trtllm]
+
+# Each framework pipeline gets a conditional:
+vllm-pipeline:
+    if: inputs.framework == '' || inputs.framework == 'vllm'
+    ...
+
+# Dev/EFA/operator/deploy jobs skip on workflow_dispatch:
+vllm-dev-pipeline:
+    if: github.event_name != 'workflow_dispatch'
+    ...
+```
+
+When dispatched on the upgrade branch via `gh workflow run post-merge-ci.yml --ref deps/upgrade-vllm-v0.18.0 -f framework=vllm`, `actions/checkout` naturally picks up the upgrade branch code with bumped versions. For NIXL upgrades, dispatch with no framework filter so all three pipelines run.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -198,42 +236,17 @@ Triggered by schedule or `workflow_dispatch` on `main`. Detects new versions, cr
                        │
                        ▼
               ┌─────────────────────┐
-              │   dispatch phase 2  │
-              │  gh workflow run    │
-              │  dep-upgrade-       │
-              │  test.yml           │
-              │  --ref <branch>     │
-              └─────────────────────┘
-```
-
-### Phase 2: Build, Test, and PR
-
-**Location**: `.github/workflows/dep-upgrade-test.yml`
-
-Triggered via `workflow_dispatch` on the upgrade branch. Since it runs in the context of the upgrade branch, all `actions/checkout` calls naturally pick up the bumped version files.
-
-```
-┌─────────────────────────────────────────────────────────┐
-│  Trigger: workflow_dispatch on upgrade branch            │
-│  Inputs: framework, version                              │
-└────────────────────────┬────────────────────────────────┘
-                         │
-                         ▼
-              ┌─────────────────────┐
-              │   setup             │
-              │  (resolve framework │
-              │   → CUDA versions,  │
-              │   test markers)     │
+              │   dispatch          │
+              │   post-merge-ci     │
+              │   --ref <branch>    │
+              │   -f framework=X    │
               └────────┬────────────┘
                        │
                        ▼
               ┌─────────────────────┐
-              │   build-and-test    │
-              │  (build-test-       │
-              │   distribute-       │
-              │   flavor-matrix)    │
-              │  per framework      │
-              │  (nixl → all 3)     │
+              │   gh run watch      │
+              │   (wait for         │
+              │    completion)      │
               └────────┬────────────┘
                        │
               ┌────────┴────────┐
@@ -248,146 +261,6 @@ Triggered via `workflow_dispatch` on the upgrade branch. Since it runs in the co
      └────────────┘    └──────────────┘
 ```
 
-**Implementation**: The `setup` job resolves framework-specific configuration because `workflow_call` inputs cannot use conditionals. For NIXL upgrades, the workflow runs all three framework pipelines (vLLM, SGLang, TRTLLM) in parallel since NIXL is a shared dependency built into each framework's container.
-
-```yaml
-# dep-upgrade-test.yml (sketch)
-name: Dependency Upgrade Test
-
-on:
-  workflow_dispatch:
-    inputs:
-      framework:
-        description: 'Framework being upgraded'
-        required: true
-        type: choice
-        options: [vllm, sglang, trtllm, nixl]
-      version:
-        description: 'Version being upgraded to'
-        required: true
-        type: string
-
-jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      # Which framework builds to run (nixl → all three)
-      run_vllm: ${{ steps.config.outputs.run_vllm }}
-      run_sglang: ${{ steps.config.outputs.run_sglang }}
-      run_trtllm: ${{ steps.config.outputs.run_trtllm }}
-    steps:
-      - id: config
-        run: |
-          case "${{ inputs.framework }}" in
-            vllm)
-              echo "run_vllm=true"   >> $GITHUB_OUTPUT
-              echo "run_sglang=false" >> $GITHUB_OUTPUT
-              echo "run_trtllm=false" >> $GITHUB_OUTPUT
-              ;;
-            sglang)
-              echo "run_vllm=false"  >> $GITHUB_OUTPUT
-              echo "run_sglang=true" >> $GITHUB_OUTPUT
-              echo "run_trtllm=false" >> $GITHUB_OUTPUT
-              ;;
-            trtllm)
-              echo "run_vllm=false"   >> $GITHUB_OUTPUT
-              echo "run_sglang=false" >> $GITHUB_OUTPUT
-              echo "run_trtllm=true"  >> $GITHUB_OUTPUT
-              ;;
-            nixl)
-              # NIXL is built into all frameworks — validate all three
-              echo "run_vllm=true"   >> $GITHUB_OUTPUT
-              echo "run_sglang=true" >> $GITHUB_OUTPUT
-              echo "run_trtllm=true" >> $GITHUB_OUTPUT
-              ;;
-          esac
-
-  vllm-pipeline:
-    needs: [setup]
-    if: needs.setup.outputs.run_vllm == 'true'
-    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
-    with:
-      framework: vllm
-      target: runtime
-      platforms: '["amd64"]'
-      cuda_versions: '["12.9"]'
-      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 180
-      copy_to_acr: false
-      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
-      single_gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1'
-      multi_gpu_test_markers: '(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4)'
-      cpu_only_test_timeout_minutes: 60
-      single_gpu_test_timeout_minutes: 60
-      multi_gpu_test_timeout_minutes: 60
-    secrets: inherit
-
-  sglang-pipeline:
-    needs: [setup]
-    if: needs.setup.outputs.run_sglang == 'true'
-    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
-    with:
-      framework: sglang
-      target: runtime
-      platforms: '["amd64"]'
-      cuda_versions: '["12.9"]'
-      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 180
-      copy_to_acr: false
-      cpu_only_test_markers: '(pre_merge or post_merge) and sglang and gpu_0'
-      single_gpu_test_markers: '(pre_merge or post_merge) and sglang and gpu_1'
-      multi_gpu_test_markers: '(pre_merge or post_merge) and sglang and (gpu_2 or gpu_4)'
-      cpu_only_test_timeout_minutes: 60
-      single_gpu_test_timeout_minutes: 60
-      multi_gpu_test_timeout_minutes: 60
-    secrets: inherit
-
-  trtllm-pipeline:
-    needs: [setup]
-    if: needs.setup.outputs.run_trtllm == 'true'
-    uses: ./.github/workflows/build-test-distribute-flavor-matrix.yml
-    with:
-      framework: trtllm
-      target: runtime
-      platforms: '["amd64"]'
-      cuda_versions: '["13.1"]'
-      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
-      build_timeout_minutes: 180
-      copy_to_acr: false
-      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
-      single_gpu_test_markers: '(pre_merge or post_merge) and trtllm and gpu_1'
-      multi_gpu_test_markers: '(pre_merge or post_merge) and trtllm and (gpu_2 or gpu_4)'
-      cpu_only_test_timeout_minutes: 60
-      single_gpu_test_timeout_minutes: 60
-      multi_gpu_test_timeout_minutes: 60
-    secrets: inherit
-
-  create-pr:
-    needs: [setup, vllm-pipeline, sglang-pipeline, trtllm-pipeline]
-    if: |
-      always() &&
-      (needs.vllm-pipeline.result == 'success' || needs.vllm-pipeline.result == 'skipped') &&
-      (needs.sglang-pipeline.result == 'success' || needs.sglang-pipeline.result == 'skipped') &&
-      (needs.trtllm-pipeline.result == 'success' || needs.trtllm-pipeline.result == 'skipped') &&
-      !contains(needs.*.result, 'failure')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Create PR with version summary and build link
-
-  notify-failure:
-    needs: [setup, vllm-pipeline, sglang-pipeline, trtllm-pipeline]
-    if: always() && contains(needs.*.result, 'failure')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack + cleanup branch
-        # Slack webhook + delete branch
-```
-
 ### Schedule
 
 Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit worker contention:
@@ -399,23 +272,15 @@ Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit work
 | TRTLLM | Wed 10:00 UTC | NVIDIA release cadence |
 | NIXL | Fri 10:00 UTC | Internal project |
 
-### Build and Test Configuration Per Framework
+### Build and Test Configuration
 
-The trial run uses the same test markers as post-merge CI but on a single platform (amd64) and primary CUDA version to balance coverage with resource cost.
+Since phase 2 reuses `post-merge-ci.yml` directly, all CUDA versions, platforms, test markers, and timeouts are inherited from the existing post-merge configuration. No separate configuration is needed.
 
-| Framework | CUDA Version | CPU Test Markers | Single GPU Markers | Multi GPU Markers |
-|-----------|-------------|------------------|--------------------|--------------------|
-| vLLM | `["12.9"]` | `(pre_merge or post_merge) and vllm and gpu_0` | `(pre_merge or post_merge) and vllm and gpu_1` | `(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4)` |
-| SGLang | `["12.9"]` | `(pre_merge or post_merge) and sglang and gpu_0` | `(pre_merge or post_merge) and sglang and gpu_1` | `(pre_merge or post_merge) and sglang and (gpu_2 or gpu_4)` |
-| TRTLLM | `["13.1"]` | `(pre_merge or post_merge) and trtllm and gpu_0` | `(pre_merge or post_merge) and trtllm and gpu_1` | `(pre_merge or post_merge) and trtllm and (gpu_2 or gpu_4)` |
-| NIXL | N/A | Built as part of other framework builds; triggers vLLM, SGLang, and TRTLLM build+test for validation | | |
-
-Test timeouts follow post-merge CI: 60 minutes for CPU, single GPU, and multi-GPU test tiers. Images are NOT copied to ACR (`copy_to_acr: false`) since these are trial builds.
+For single-framework upgrades (vllm, sglang, trtllm), only that framework's pipeline runs. For NIXL upgrades, all three framework pipelines run since NIXL is a shared dependency.
 
 ### Permissions
 
-- **Phase 1** (`dep-upgrade-release.yml`): `contents: write` (to push branches) and `actions: write` (to dispatch phase 2 via `gh workflow run`)
-- **Phase 2** (`dep-upgrade-test.yml`): `contents: write` (to delete branch on failure) and `pull-requests: write` (to create PRs)
+- `dep-upgrade-release.yml`: `contents: write` (to push/delete branches), `actions: write` (to dispatch post-merge CI via `gh workflow run`), `pull-requests: write` (to create PRs)
 
 The `GITHUB_TOKEN` is sufficient for same-repository operations.
 
@@ -433,8 +298,8 @@ Implement the full release detection and upgrade PR pipeline for all 4 framework
 **Deliverables:**
 - `.github/scripts/detect_latest_versions.py` — version detection from upstream sources
 - `.github/scripts/bump_dependency.py` — coordinated multi-file version bump
-- `.github/workflows/dep-upgrade-release.yml` — phase 1: detect, branch, bump, dispatch
-- `.github/workflows/dep-upgrade-test.yml` — phase 2: build, test, PR/notify (runs on upgrade branch)
+- `.github/workflows/dep-upgrade-release.yml` — detect, branch, bump, dispatch post-merge CI, wait, create PR/notify
+- `.github/workflows/post-merge-ci.yml` — **modified**: add `workflow_dispatch` trigger with framework filter
 - `.github/workflows/dep-upgrade-all.yml` — optional orchestrator for manual triggers
 
 **Rollout:**

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -207,34 +207,32 @@ vllm-dev-pipeline:
 
 The two upgrade workflows are connected via GitHub's `workflow_run` trigger — no polling, no idle runners:
 
-```
-  auto-dep-upgrade-trigger.yml         post-merge-ci.yml          auto-dep-upgrade-complete.yml
-  ────────────────────────────         ─────────────────          ────────────────────────────
-  schedule / workflow_dispatch
-            │
-            ▼
-     detect latest version
-            │
-      no update? ──→ exit
-            │
-            ▼
-     create branch + bump
-            │
-            ▼
-     gh workflow run ──────────→ runs on upgrade branch
-     post-merge-ci.yml           (full build + test)
-     --ref <branch>                      │
-            │                            │
-          exit                       completes
-                                         │
-                                         ▼
-                                  workflow_run ─────────→ check conclusion
-                                  trigger fires                │
-                                                         ┌─────┴─────┐
-                                                      success     failure
-                                                         │           │
-                                                         ▼           ▼
-                                                     create PR   Slack notify
+```mermaid
+flowchart LR
+    subgraph trigger["auto-dep-upgrade-trigger.yml"]
+        direction TB
+        A[Schedule / dispatch] --> B[Detect latest version]
+        B --> C{New release?}
+        C -- No --> D[Exit]
+        C -- Yes --> E{PR exists?}
+        E -- Yes --> D
+        E -- No --> F[Create branch + bump]
+    end
+
+    subgraph postmerge["post-merge-ci.yml"]
+        direction TB
+        H[Build + test\non upgrade branch]
+    end
+
+    subgraph complete["auto-dep-upgrade-complete.yml"]
+        direction TB
+        J{Conclusion?}
+        J -- success --> K[Create PR]
+        J -- failure --> L[Slack notify]
+    end
+
+    F -- "gh workflow run\n--ref branch" --> H
+    H -- "workflow_run\ntrigger" --> J
 ```
 
 ### `auto-dep-upgrade-trigger.yml`

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -6,11 +6,11 @@
 
 **Category**: Process - CI/CD
 
-**Sponsor**: TBD
+**Sponsor**: Meenakshi Sharma
 
-**Required Reviewers**: TBD
+**Required Reviewers**: Neelay, Dillon
 
-**Review Date**: TBD
+**Review Date**: March 31, 2026
 
 **Pull Request**: TBD
 

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -208,33 +208,33 @@ vllm-dev-pipeline:
 The two upgrade workflows are connected via GitHub's `workflow_run` trigger — no polling, no idle runners:
 
 ```
-  auto-dep-upgrade-trigger.yml              post-merge-ci.yml             auto-dep-upgrade-complete.yml
-  ─────────────────────────────             ─────────────────             ────────────────────────────
+  auto-dep-upgrade-trigger.yml         post-merge-ci.yml          auto-dep-upgrade-complete.yml
+  ────────────────────────────         ─────────────────          ────────────────────────────
   schedule / workflow_dispatch
-           │
-           ▼
-    detect latest version
-           │
-     no update? ──→ exit
-           │
-           ▼
-    create branch + bump
-           │
-           ▼
-    gh workflow run ─────────→  runs on upgrade branch
-    post-merge-ci.yml            (full build + test)
-    --ref <branch>                       │
-           │                             │
-         exit                        completes
+            │
+            ▼
+     detect latest version
+            │
+      no update? ──→ exit
+            │
+            ▼
+     create branch + bump
+            │
+            ▼
+     gh workflow run ──────────→ runs on upgrade branch
+     post-merge-ci.yml           (full build + test)
+     --ref <branch>                      │
+            │                            │
+          exit                       completes
                                          │
                                          ▼
-                               workflow_run trigger ──→  check conclusion
-                               (branches: deps/upgrade-*)     │
-                                                        ┌─────┴─────┐
-                                                     success     failure
-                                                        │           │
-                                                        ▼           ▼
-                                                    create PR   Slack notify
+                                  workflow_run ─────────→ check conclusion
+                                  trigger fires                │
+                                                         ┌─────┴─────┐
+                                                      success     failure
+                                                         │           │
+                                                         ▼           ▼
+                                                     create PR   Slack notify
 ```
 
 ### `auto-dep-upgrade-trigger.yml`
@@ -346,6 +346,7 @@ name: Auto Dependency Upgrade Complete
 
 on:
   workflow_run:
+    # TODO: fragile name coupling — consider repository_dispatch as alternative
     workflows: ["Post-Merge CI Pipeline"]
     types: [completed]
     branches:
@@ -483,14 +484,14 @@ This workflow would run on a separate schedule, report pass/fail to Slack, and w
 | vLLM install | `container/deps/vllm/install_vllm.sh` | `VLLM_VER="0.17.1"` |
 | NIXL install (container) | `container/deps/trtllm/install_nixl.sh` | `NIXL_COMMIT="0.10.1"` |
 | NIXL install (deploy) | `deploy/pre-deployment/nixl/build_and_deploy.sh` | `NIXL_VERSION="0.10.1"` |
-| Documentation | `docs/reference/support-matrix.md` | Version compatibility table |
+| NIXL deploy docs | `deploy/pre-deployment/nixl/README.md` | `version 0.10.1` |
+| Support matrix | `docs/reference/support-matrix.md` | `main (ToT)` row in Backend Dependencies table |
 
 ## Current CI Build Infrastructure
 
-The existing CI already supports the building blocks needed:
-- `build-test-distribute-flavor-matrix.yml` accepts `build_only: true` for build-without-test runs
-- `build-flavor` composite action supports `extra_build_args` and `sanitized_ref_name` for branch-tagged builds
-- BuildKit workers are routed by framework flavor
+The existing CI infrastructure is reused directly:
+- `post-merge-ci.yml` runs full build + test for all frameworks — dispatched on the upgrade branch via `workflow_dispatch`
+- `workflow_run` trigger enables the completion workflow to react when post-merge CI finishes
 - Slack notifications use `SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL`
 
 ## Upstream Release Sources
@@ -502,11 +503,3 @@ The existing CI already supports the building blocks needed:
 | TRTLLM | [pypi.nvidia.com/tensorrt-llm](https://pypi.nvidia.com/tensorrt-llm/) | `1.3.0rc7` |
 | NIXL | [github.com/ai-dynamo/nixl/releases](https://github.com/ai-dynamo/nixl/releases) | `0.10.1` |
 | SGLang Docker | [hub.docker.com/r/lmsysorg/sglang](https://hub.docker.com/r/lmsysorg/sglang/tags) | `v0.5.9-runtime`, `v0.5.9-cu130-runtime` |
-
-## Acronyms & Abbreviations
-
-**TRTLLM**: TensorRT Large Language Model (NVIDIA's LLM inference engine)
-
-**NIXL**: NVIDIA Inference eXchange Library (GPU-to-GPU data transfer library)
-
-**DEP**: Dynamo Enhancement Proposal

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -247,8 +247,7 @@ name: Auto Dependency Upgrade Trigger
 
 on:
   schedule:
-    # Wed: all frameworks
-    - cron: '0 10 * * 3'
+    - cron: '0 10 * * *'
   workflow_dispatch:
     inputs:
       framework:
@@ -422,7 +421,7 @@ Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit work
 
 | Day | Frameworks | Schedule |
 |-----|-----------|----------|
-| Wednesday | All (vLLM, SGLang, TRTLLM, NIXL) | 10:00 UTC |
+| Everyday | All (vLLM, SGLang, TRTLLM, NIXL) | 10:00 UTC |
 
 Single mid-week schedule. All frameworks run in parallel via matrix strategy with `fail-fast: false`. The workflow also supports `workflow_dispatch` for manual triggers when someone wants to upgrade a specific framework outside of the regular cadence.
 

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -205,7 +205,7 @@ vllm-dev-pipeline:
     ...
 ```
 
-The two upgrade workflows are connected via GitHub's `workflow_run` trigger — no polling, no idle runners:
+The two upgrade workflows are connected via GitHub's `workflow_run` trigger:
 
 ```
 auto-dep-upgrade-trigger.yml    ┊  post-merge-ci.yml           ┊  auto-dep-upgrade-complete.yml

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -1,0 +1,312 @@
+# Automated Dependency Upgrade Pipelines
+
+**Status**: Draft
+
+**Authors**: Anant
+
+**Category**: Process - CI/CD
+
+**Sponsor**: TBD
+
+**Required Reviewers**: TBD
+
+**Review Date**: TBD
+
+**Pull Request**: TBD
+
+**Implementation PR / Tracking Issue**: TBD
+
+# Summary
+
+Introduce automated CI pipelines that detect new releases of Dynamo's core framework dependencies (vLLM, TensorRT-LLM, SGLang, NIXL), validate compatibility by running trial container builds, and create upgrade pull requests when builds succeed. This replaces the current fully manual upgrade process and reduces the time between an upstream release and a Dynamo upgrade.
+
+# Motivation
+
+Dynamo depends on four fast-moving upstream frameworks: vLLM, TensorRT-LLM (TRTLLM), SGLang, and NIXL. Each upgrade currently requires manual, coordinated changes across 6+ files (`container/context.yaml`, `pyproject.toml`, `install_vllm.sh`, `install_nixl.sh`, documentation). This process is:
+
+- **Slow**: Engineers must discover new releases, understand what changed, and manually update multiple files.
+- **Error-prone**: Version references are scattered across YAML, TOML, and shell scripts with no single-command update path.
+- **Reactive**: The team only learns about breaking changes after attempting an upgrade, rather than catching them early through continuous integration.
+
+Recent examples of manual upgrades include `chore: bump trtllm to 1.3.0rc7` and `chore: Advance deepseek wideep and qwen-235b recipes to 1.0.1 TRTLLM version` — each touching multiple files with framework-specific update logic.
+
+## Goals
+
+* Automatically detect when a new stable release is available for vLLM, TRTLLM, SGLang, or NIXL
+
+* Validate that Dynamo's container images build successfully with the new version before involving a human
+
+* Create draft pull requests with all necessary file changes when a build succeeds
+
+* Notify the team via Slack when an upgrade build fails so breaking changes are surfaced early
+
+* Reduce the manual effort for dependency upgrades to reviewing and merging a pre-built PR
+
+### Non Goals
+
+* Fully automated merging of upgrade PRs (human review is still required)
+
+* Upgrading transitive dependencies (e.g., `transformers`, `torch`) — these require manual analysis
+
+* Upgrading recipe YAML files or documentation (flagged in PR for manual review)
+
+## Requirements
+
+### REQ 1 Version Detection
+
+The system **MUST** detect the latest stable release for each framework from its canonical source:
+- vLLM: GitHub releases (`vllm-project/vllm`)
+- SGLang: GitHub releases (`sgl-project/sglang`) + Docker Hub image tag verification (`lmsysorg/sglang`)
+- TRTLLM: NVIDIA PyPI index (`pypi.nvidia.com/tensorrt-llm`)
+- NIXL: GitHub releases (`ai-dynamo/nixl`)
+
+The system **MUST** compare the detected version against the currently pinned version in `container/context.yaml` and **MUST** skip the workflow if no upgrade is available.
+
+### REQ 2 Coordinated Multi-File Version Bump
+
+The system **MUST** update version references consistently across all files where a framework version is pinned. At minimum:
+
+| File | vLLM | SGLang | TRTLLM | NIXL |
+|------|------|--------|--------|------|
+| `container/context.yaml` | `vllm_ref` (per CUDA ver) | `runtime_image_tag` (per CUDA ver) | `pip_wheel`, `github_trtllm_commit` | `nixl_ref` |
+| `pyproject.toml` | `vllm==X.Y.Z` | `sglang==X.Y.Z` | `tensorrt-llm==X.Y.Z` | `nixl<=X.Y.Z` |
+| `container/deps/vllm/install_vllm.sh` | `VLLM_VER` (line 15) | — | — | — |
+| `container/deps/trtllm/install_nixl.sh` | — | — | — | `NIXL_COMMIT` (line 30) |
+
+The system **SHOULD** flag files requiring manual review in the PR body (docs, recipes, `requirements.common.txt`, trtllm torch versions).
+
+### REQ 3 Trial Build Validation
+
+The system **MUST** run a container build for the target framework on at least one platform (amd64) and one CUDA version before creating a PR. The build **MUST** reuse the existing `build-test-distribute-flavor-matrix.yml` workflow with `build_only: true`.
+
+### REQ 4 Pull Request Creation
+
+On successful build, the system **MUST** create a pull request with:
+- Title: `chore: bump {framework} to {version}`
+- Labels: `dep-upgrade`, `{framework}`
+- Body containing: version change summary, build log link, manual review checklist
+
+If a prior open PR exists for the same framework, the system **SHOULD** close it and create a fresh one.
+
+### REQ 5 Failure Notification
+
+On build failure, the system **MUST** send a Slack notification including the framework name, attempted version, and a link to the build logs.
+
+### REQ 6 Independent Framework Scheduling
+
+Each framework **MUST** be independently schedulable. A failure in one framework's upgrade pipeline **MUST NOT** block or delay other frameworks.
+
+# Proposal
+
+## Overview
+
+The solution consists of three components:
+
+1. **Version detection script** (`detect_latest_versions.py`) — queries upstream sources for latest releases
+2. **Version bump script** (`bump_dependency.py`) — performs coordinated multi-file version updates
+3. **GitHub Actions workflow** (`dep-upgrade-release.yml`) — orchestrates detection → branch → build → PR/notify
+
+The workflow is branch-based: it creates a temporary branch with the version bump changes, runs the existing build infrastructure against it, and either opens a PR (on success) or cleans up and notifies (on failure).
+
+## Version Detection Script
+
+**Location**: `.github/scripts/detect_latest_versions.py`
+
+A standalone Python script (stdlib only + `urllib`) that queries upstream package sources.
+
+```
+$ python detect_latest_versions.py --framework vllm
+{"framework": "vllm", "current": "v0.17.1", "latest": "v0.18.0", "needs_update": true}
+```
+
+| Framework | Source | API |
+|-----------|--------|-----|
+| vLLM | GitHub | `GET /repos/vllm-project/vllm/releases` → filter non-prerelease → highest semver |
+| SGLang | GitHub + Docker Hub | `GET /repos/sgl-project/sglang/releases` + verify `lmsysorg/sglang:v{ver}-runtime` tag exists |
+| TRTLLM | NVIDIA PyPI | Parse simple repository index at `pypi.nvidia.com/tensorrt-llm/` |
+| NIXL | GitHub | `GET /repos/ai-dynamo/nixl/releases` → latest |
+
+The script reads the current pinned version from `container/context.yaml` for comparison. It uses `GITHUB_TOKEN` for API authentication to avoid rate limits.
+
+## Version Bump Script
+
+**Location**: `.github/scripts/bump_dependency.py`
+
+A Python script that modifies version strings across all relevant files for a given framework.
+
+```
+$ python bump_dependency.py --framework vllm --version v0.18.0
+Updated container/context.yaml: vllm_ref v0.17.1 -> v0.18.0
+Updated pyproject.toml: vllm==0.17.1 -> vllm==0.18.0
+Updated container/deps/vllm/install_vllm.sh: VLLM_VER 0.17.1 -> 0.18.0
+```
+
+Implementation approach:
+- YAML files: parsed with `pyyaml` (available in CI runners)
+- TOML files: regex-based substitution (avoids needing `tomli_w` and preserves formatting/comments)
+- Shell scripts: regex substitution on known variable assignment patterns
+
+### SGLang-Specific Bump Logic
+
+SGLang's `runtime_image_tag` in `context.yaml` has CUDA-dependent suffixes:
+- CUDA 12.9: `v{version}-runtime`
+- CUDA 13.0: `v{version}-cu130-runtime`
+
+The bump script **MUST** verify the Docker image tags exist on Docker Hub before writing changes.
+
+### TRTLLM-Specific Constraints
+
+Only `pip_wheel` and `github_trtllm_commit` are auto-bumped. The torch ecosystem versions (`torch_version`, `pytorch_triton_ver`, `torchao_ver`, etc.) are tied to the NGC PyTorch base image, not to the TRTLLM version, and **MUST NOT** be automatically modified.
+
+### NIXL Cross-Reference
+
+NIXL appears in both the `vllm` and `sglang` optional dependency sections of `pyproject.toml`. The bump script **MUST** update both references.
+
+## Workflow
+
+**Location**: `.github/workflows/dep-upgrade-release.yml`
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Trigger: cron (per-framework) or workflow_dispatch      │
+└────────────────────────┬────────────────────────────────┘
+                         │
+                         ▼
+              ┌─────────────────────┐
+              │   detect-release    │
+              │  (latest version?)  │
+              └────────┬────────────┘
+                       │
+              ┌────────┴────────┐
+              │ no new release  │──→ exit(0)
+              └─────────────────┘
+                       │ new release found
+                       ▼
+              ┌─────────────────────┐
+              │   prepare-branch    │
+              │  (create branch,    │
+              │   bump versions,    │
+              │   commit & push)    │
+              └────────┬────────────┘
+                       │
+                       ▼
+              ┌─────────────────────┐
+              │   trial-build       │
+              │  (build-test-       │
+              │   distribute-       │
+              │   flavor-matrix)    │
+              │  build_only: true   │
+              │  amd64 only         │
+              └────────┬────────────┘
+                       │
+              ┌────────┴────────┐
+              │                 │
+         success            failure
+              │                 │
+              ▼                 ▼
+     ┌────────────┐    ┌──────────────┐
+     │ create-pr  │    │ notify-slack │
+     │ (gh pr     │    │ + cleanup    │
+     │  create)   │    │   branch     │
+     └────────────┘    └──────────────┘
+```
+
+### Schedule
+
+Staggered from nightly CI (08:00 UTC) and from each other to avoid BuildKit worker contention:
+
+| Framework | Schedule | Rationale |
+|-----------|----------|-----------|
+| vLLM | Mon + Thu 10:00 UTC | High upstream velocity |
+| SGLang | Tue 10:00 UTC | Moderate velocity |
+| TRTLLM | Wed 10:00 UTC | NVIDIA release cadence |
+| NIXL | Fri 10:00 UTC | Internal project |
+
+### Build Configuration Per Framework
+
+| Framework | CUDA Version | Notes |
+|-----------|-------------|-------|
+| vLLM | `["12.9"]` | Primary CUDA version |
+| SGLang | `["12.9"]` | Primary CUDA version |
+| TRTLLM | `["13.1"]` | Only supported CUDA version |
+| NIXL | N/A | Built as part of vLLM build; trigger vLLM build for validation |
+
+### Permissions
+
+The workflow requires `contents: write` (to push branches) and `pull-requests: write` (to create PRs). The `GITHUB_TOKEN` is sufficient for same-repository operations.
+
+### PR Lifecycle
+
+- Branch naming: `deps/upgrade-{framework}-{version}`
+- If an open PR with labels `[dep-upgrade, {framework}]` already exists for an older version: close the old PR, delete the old branch, then create the new one
+- If an open PR exists for the same version: skip (already in progress)
+
+# Implementation Phases
+
+## Phase 1: Release Upgrade Pipelines
+
+Implement the full release detection and upgrade PR pipeline for all 4 frameworks.
+
+**Deliverables:**
+- `.github/scripts/detect_latest_versions.py` — version detection from upstream sources
+- `.github/scripts/bump_dependency.py` — coordinated multi-file version bump
+- `.github/workflows/dep-upgrade-release.yml` — main upgrade workflow
+- `.github/workflows/dep-upgrade-all.yml` — optional orchestrator for manual triggers
+
+**Rollout:**
+1. Scripts developed and tested locally
+2. Workflow deployed with `workflow_dispatch` trigger only (no cron)
+3. Manual validation for each framework
+4. Cron schedules enabled after validation
+
+## Phase 2: Top-of-Main Integration Testing (Future)
+
+Once release tracking is proven stable, add a separate workflow that builds against upstream `main` branches to catch breaking changes before they ship in a release.
+
+**vLLM**: Add `--build-from-source` flag to `install_vllm.sh` for CUDA source builds (currently only CPU/XPU paths build from source). Add `VLLM_BUILD_FROM_SOURCE` ARG to `vllm_framework.Dockerfile`.
+
+**NIXL**: Already builds from source — point `NIXL_COMMIT` to `main`.
+
+**SGLang**: Use `lmsysorg/sglang:nightly-dev-*` Docker images (published daily on Docker Hub). Modify `sglang_runtime.Dockerfile` to detect nightly tags and skip version-pinned `pip install sglang==` (sglang is pre-installed in nightly images).
+
+**TRTLLM**: Test against latest PyPI pre-release/RC versions. Source builds are impractical due to the massive C++ compilation required.
+
+This workflow would run on a separate schedule, report pass/fail to Slack, and would NOT create PRs since `main` is a moving target.
+
+# Background
+
+## Current Version Pinning Locations
+
+| Source | File | Example |
+|--------|------|---------|
+| Container builds | `container/context.yaml` | `vllm_ref: v0.17.1` |
+| Python packages | `pyproject.toml` | `vllm[flashinfer,runai]==0.17.1` |
+| vLLM install | `container/deps/vllm/install_vllm.sh` | `VLLM_VER="0.17.1"` |
+| NIXL install | `container/deps/trtllm/install_nixl.sh` | `NIXL_COMMIT="0.10.1"` |
+| Documentation | `docs/reference/support-matrix.md` | Version compatibility table |
+
+## Current CI Build Infrastructure
+
+The existing CI already supports the building blocks needed:
+- `build-test-distribute-flavor-matrix.yml` accepts `build_only: true` for build-without-test runs
+- `build-flavor` composite action supports `extra_build_args` and `sanitized_ref_name` for branch-tagged builds
+- BuildKit workers are routed by framework flavor
+- Slack notifications use `SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL`
+
+## Upstream Release Sources
+
+| Framework | Release Source | Tag Pattern |
+|-----------|--------------|-------------|
+| vLLM | [github.com/vllm-project/vllm/releases](https://github.com/vllm-project/vllm/releases) | `v0.17.1` |
+| SGLang | [github.com/sgl-project/sglang/releases](https://github.com/sgl-project/sglang/releases) | `v0.5.9` |
+| TRTLLM | [pypi.nvidia.com/tensorrt-llm](https://pypi.nvidia.com/tensorrt-llm/) | `1.3.0rc7` |
+| NIXL | [github.com/ai-dynamo/nixl/releases](https://github.com/ai-dynamo/nixl/releases) | `0.10.1` |
+| SGLang Docker | [hub.docker.com/r/lmsysorg/sglang](https://hub.docker.com/r/lmsysorg/sglang/tags) | `v0.5.9-runtime`, `v0.5.9-cu130-runtime` |
+
+## Acronyms & Abbreviations
+
+**TRTLLM**: TensorRT Large Language Model (NVIDIA's LLM inference engine)
+
+**NIXL**: NVIDIA Inference eXchange Library (GPU-to-GPU data transfer library)
+
+**DEP**: Dynamo Enhancement Proposal

--- a/deps/0014-automated-dependency-upgrades.md
+++ b/deps/0014-automated-dependency-upgrades.md
@@ -48,7 +48,7 @@ Recent examples of manual upgrades include `chore: bump trtllm to 1.3.0rc7` and 
 
 * Upgrading transitive dependencies (e.g., `transformers`, `torch`) — these require manual analysis
 
-* Upgrading recipe YAML files or documentation (flagged in PR for manual review)
+* Upgrading recipe YAML files (these reference Dynamo release versions, not upstream framework versions)
 
 ## Requirements
 
@@ -90,7 +90,7 @@ The system **MUST** run the full post-merge CI pipeline for the target framework
 
 On successful build, the system **MUST** create a pull request with:
 - Title: `chore: bump {framework} to {version}`
-- Labels: `dep-upgrade`, `{framework}`
+- Labels: `dep-upgrade`, `backend::{framework}`
 - Body containing: version change summary, build log link, manual review checklist
 
 If a prior open PR exists for the same framework and version, the system **SHOULD** skip creating a duplicate.
@@ -302,8 +302,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          EXISTING=$(gh pr list --label "dep-upgrade" \
-            --label "${{ matrix.framework }}" --json title --jq 'length')
+          VERSION="${{ steps.detect.outputs.latest_version }}"
+          BRANCH="deps/upgrade-${{ matrix.framework }}-${VERSION}"
+          EXISTING=$(gh pr list --head "$BRANCH" --json title --jq 'length')
           if [ "$EXISTING" -gt 0 ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
@@ -387,7 +388,7 @@ jobs:
             --head "${{ github.event.workflow_run.head_branch }}" \
             --title "chore: bump ${{ steps.parse.outputs.framework }} to ${{ steps.parse.outputs.version }}" \
             --label "dep-upgrade" \
-            --label "${{ steps.parse.outputs.framework }}" \
+            --label "backend::${{ steps.parse.outputs.framework }}" \
             --body "$(cat <<EOF
           ## Dependency Upgrade
 


### PR DESCRIPTION
Dynamo's core framework dependencies (vLLM, TensorRT-LLM, SGLang, NIXL) are upgraded manually across 6+ files, which is slow and error-prone. This DEP proposes automated CI pipelines that detect new upstream releases, run trial container builds via the existing post-merge CI, and create draft upgrade PRs when builds  succeed.

The proposal covers:
  - Version detection scripts querying GitHub releases, Docker Hub, and NVIDIA PyPI
  - A coordinated multi-file bump script that updates `context.yaml`, `pyproject.toml`, install scripts, and docs in one shot
  - A two-workflow design: a trigger workflow that detects versions and dispatches post-merge CI, and a completion workflow that reacts via `workflow_run` to create PRs or send Slack failure notifications
  - Minimal changes to `post-merge-ci.yml` (add `workflow_dispatch` with a framework filter input)
  - A future Phase 2 for top-of-main integration testing against upstream `main` branches