### PR TITLE
feat: kvbm-v2 xpu-sycl enablement

### DIFF
--- a/deps/0016-kvbm-v2-xpu-sycl-enablement/collectives.md
+++ b/deps/0016-kvbm-v2-xpu-sycl-enablement/collectives.md
@@ -1,0 +1,256 @@
+# Collectives — NCCL and oneCCL
+
+Runtime behavior of the two `CollectiveOps` implementations in
+`kvbm-engine`. This document focuses on *how broadcasts execute*: the
+bootstrap protocol, the event model, and the differences between the two
+backends at the call level.
+
+For the broader architecture — which crates own which traits, how the
+device backend is selected, what `kvbm-v2` as a whole looks like — see
+[`kvbm_v2_xpu_sycl_enablement.md`](../../kvbm-physical/docs/kvbm_v2_xpu_sycl_enablement.md).
+
+## The trait
+
+```rust
+pub trait CollectiveOps: Send + Sync {
+    fn broadcast(
+        &self,
+        src: LogicalLayoutHandle,   // e.g. G1 on rank 0
+        dst: LogicalLayoutHandle,   // e.g. G1 on all ranks
+        src_block_ids: &[BlockId],
+        dst_block_ids: &[BlockId],
+        layer_range: Option<Range<usize>>,
+    ) -> Result<TransferCompleteNotification>;
+
+    fn rank(&self) -> usize;
+    fn world_size(&self) -> usize;
+}
+```
+
+Three concrete implementations ship in the crate:
+
+| Impl | Module | Feature | Backend |
+|---|---|---|---|
+| `StubCollectiveOps` | `collectives::stub` | always available | no-op; tests and single-worker paths |
+| `NcclCollectives` | `collectives::nccl` | `nccl` | CUDA via `cudarc::nccl` |
+| `OneCclCollectives` | `collectives::oneccl` | `oneccl` | SYCL/XPU via `oneapi-rs::ccl` |
+
+Both real backends take a `LayoutResolver` (for mapping logical G1/G2/G3
+handles to physical layouts) and an `EventManager` from the runtime.
+
+## Construction paths
+
+Each real backend exposes the same two construction shapes:
+
+| Path | NCCL | oneCCL | Used by |
+|---|---|---|---|
+| From-scratch bootstrap | `NcclCollectives::from_bootstrap` | `OneCclCollectives::from_bootstrap` | tests, standalone Rust apps |
+| Borrowed communicator | `NcclCollectives::from_borrowed` | `OneCclCollectives::from_borrowed` | production via PyTorch / vLLM / torchrun |
+
+The "borrowed" paths exist because inference runtimes already own a
+communicator — `torch.distributed` creates one for `nccl` and for
+`ccl`. KVBM borrows it rather than creating a second one.
+
+## oneCCL bootstrap — step by step
+
+```mermaid
+sequenceDiagram
+    participant R0 as Rank 0
+    participant Net as OOB channel<br/>(MPI, torchrun, env var…)
+    participant RN as Rank N (N > 0)
+
+    R0->>R0: OneCclBootstrap::generate(world_size)<br/>ccl_rs_init + ccl_rs_kvs_create_main
+    R0->>R0: serialize() → 8 B world_size ‖ 256 B KVS address
+    R0->>Net: push serialized bootstrap
+    Net-->>RN: deserialize(bytes) on every other rank
+    RN->>RN: ccl_rs_init + ccl_rs_kvs_create_from_address
+    par Collective init
+        R0->>R0: init_communicator(0)
+        RN->>RN: init_communicator(rank)
+    end
+    Note over R0,RN: ccl_rs_comm_create is collective —<br/>all ranks must call concurrently
+```
+
+Key invariants:
+
+- `SERIALIZED_SIZE = 8 + CCL_RS_KVS_ADDRESS_SIZE` (264 bytes). Transport
+  is opaque — KVBM does not prescribe OOB (env var, TCP, filesystem
+  token, whatever the launcher offers).
+- `ccl_rs_init` is idempotent but must be called before
+  `ccl_rs_kvs_create_*`. Both `generate` and `deserialize` call it.
+- `init_communicator` is **collective**: all ranks must call it
+  concurrently or `ccl_rs_comm_create` hangs.
+
+NCCL follows the same shape with `ncclUniqueId` in place of the KVS
+address.
+
+## Broadcast flow
+
+```mermaid
+flowchart TD
+    A[broadcast src, dst, blocks, layer_range] --> B{rank == 0?}
+    B -- yes --> LAY_SRC[layout = resolve_layout src]
+    B -- no --> LAY_DST[layout = resolve_layout dst]
+
+    LAY_SRC --> BID_SRC[block_ids = src_block_ids]
+    LAY_DST --> BID_DST[block_ids = dst_block_ids]
+
+    BID_SRC --> COLLECT
+    BID_DST --> COLLECT
+
+    COLLECT[collect_regions:<br/>for each block × layer × outer<br/>layout.memory_region → usize, usize]
+
+    COLLECT --> BRC[broadcast_regions regions, root=0]
+
+    BRC --> DONE[create_completion_notification<br/>nova event, already-triggered]
+
+    style BRC fill:#ff6b35,stroke:#c44520,color:#fff
+```
+
+### `broadcast_regions` — the two backends differ here
+
+**NCCL** calls one `ncclBroadcast` per region and relies on the NCCL
+group API to coalesce them, then records a single CUDA event via the
+registered `CudaEventRegistrar` so the returned
+`TransferCompleteNotification` can be awaited asynchronously.
+
+**oneCCL**:
+
+```rust
+ccl_rs_group_start();                           // begin batch
+for (ptr, size) in regions {
+    ccl_rs_broadcast(ptr, size, UINT8, root, comm, stream, &mut event);
+    // keep only the last event for destruction
+}
+ccl_rs_group_end();                             // submit batch
+ccl_rs_event_destroy(last_event);               // per-op events in a group
+                                                // are not valid sync points
+ccl_rs_stream_wait(stream);                     // host wait —
+                                                // delegates to sycl::queue::wait()
+```
+
+All broadcasts submit as a single group, and the host blocks on the
+underlying SYCL queue after `group_end`. Per-op events returned by
+in-group collectives are not valid synchronization points (oneCCL
+logs a warning if you wait on them); the primitive for a
+group is a queue-level wait, exposed via `ccl_rs_stream_wait` from the
+`oneapi-rs` bindings.
+
+The returned `TransferCompleteNotification` is constructed with
+`event_system.new_event() → trigger() → awaiter`, i.e.
+already-triggered, so callers see immediate completion. This is
+semantically equivalent to the NCCL path *for correctness*: by the
+time `broadcast()` returns, the GPU is done.
+
+## TODO: async completion
+
+The current implementation host-blocks inside `broadcast_regions` (via
+`ccl_rs_stream_wait` for oneCCL); after that, `create_completion_notification`
+constructs an already-triggered `nova_event` so the returned
+`TransferCompleteNotification` resolves immediately
+([`oneccl.rs:345`](../src/collectives/oneccl.rs)). That's correct and
+warning-free, but stalls the calling thread for the broadcast duration
+— acceptable for the stream-ordered consumption pattern KVBM uses
+today, a problem if a future consumer wants host work to overlap with
+the broadcast.
+
+`NcclCollectives` has had a `CudaEventRegistrar` trait declared but
+no implementation. Two paths are viable.
+
+**Path A — reuse `TransferContext::register_device_event`**
+(async primitive that kvbm-physical already drives for
+local device transfers):
+
+1. `ccl_rs_stream_get_native_queue(stream, &mut raw_queue)` — reach
+   the `sycl::queue` behind the CCL stream.
+2. `oneapi_rs::ccl::sys::sycl_rs_submit_barrier(raw_queue, &mut ev)` —
+   record a SYCL barrier event at the tail of the group.
+3. Wrap the raw `sycl_rs_event_t` as `SyclEvent`, then as a
+   backend-agnostic `DeviceEvent { backend: Sycl, ops: ... }`.
+4. Hand the `DeviceEvent` to
+   `kvbm_physical::transfer::TransferContext::register_device_event`,
+   which enqueues it onto the existing shared polling task and
+   returns a real deferred `TransferCompleteNotification`.
+
+This requires injecting `Arc<TransferContext>` into `OneCclCollectives`
+but doesn't add a new trait.
+
+**Path B — `OneCclEventRegistrar` trait** (mirrors the
+declared-but-unimplemented `CudaEventRegistrar` in `nccl.rs`):
+
+Define `trait OneCclEventRegistrar { fn register_sycl_event(&self, …)
+-> TransferCompleteNotification; }` and have `OneCclCollectives` take
+`Arc<dyn OneCclEventRegistrar>`. The concrete implementation still
+forwards to `register_device_event` underneath.
+
+Both approaches use the same underlying primitives
+(`submit_barrier` + `register_device_event` polling task) — they
+differ only in whether `OneCclCollectives` takes a concrete
+`TransferContext` or an abstract trait object.
+
+## MLA pattern — where this gets used
+
+In Multi-head Latent Attention replicas, only rank 0 loads G2/G3:
+
+```
+Rank 0:   G3 disk ←→ G2 host ←→ G1 GPU ─── broadcast ───→ Other ranks G1
+Rank 1-N:                       G1 GPU ←──────────────────────────┘
+```
+
+`ReplicatedDataWorker` in `kvbm-engine` owns a `CollectiveOps` trait
+object. The execution structure is wired up in
+[`worker/physical/replicated.rs`](../src/worker/physical/replicated.rs):
+when rank 0 finishes a G2/G3 → G1 onboard, `execute_local_transfer`
+routes to `self.broadcast(...)` for the cross-rank dispatch, and
+non-rank-0 workers expect to receive the data on their own G1.
+
+The bridge into `CollectiveOps::broadcast` itself is
+**`unimplemented!()`** today — the structure is in place but the actual
+broadcast call has not yet been wired through. When implemented, each
+rank will synchronize on the returned `TransferCompleteNotification`
+before using the blocks.
+
+## Error and cleanup semantics
+
+| Event | NCCL | oneCCL |
+|---|---|---|
+| Per-rank init failure before broadcast | `ncclResult_t` returned from `ncclCommInitRank` | `ccl_rs_result_t` returned from `ccl_rs_comm_create` |
+| Mid-broadcast failure | first failing `ncclBcast` early-returns from the loop via `?`, so `ncclGroupEnd` is **not** called — the group is left dangling. (Asymmetric with oneCCL; tightening NCCL's path to "always close the group" would mirror the cleaner oneCCL behavior.) | `ccl_rs_broadcast` error breaks the loop; `ccl_rs_group_end` is **always** called (even on error) so the oneCCL runtime is left in a clean state. The broadcast error is propagated after cleanup. |
+| Communicator destruction (owned) | `ncclCommDestroy` on `Drop` | `ccl_rs_comm_destroy` on `Drop` |
+| Communicator destruction (borrowed) | host runtime (PyTorch) owns it | host runtime owns it |
+| Stream destruction (owned) | `cudarc::CudaStream` RAII frees the stream on `Drop`; KVBM doesn't drive `cuStreamDestroy` directly | `ccl_rs_stream_destroy` on `Drop` only for `CclStream::Owned` |
+
+The `CommOwnership` enum in `oneccl.rs` distinguishes `Owned` vs.
+`Borrowed` so `Drop` does not call destroy on a handle the runtime
+still owns.
+
+## Feature flags
+
+```toml
+# lib/kvbm-engine/Cargo.toml
+nccl       = ["dep:cudarc"]
+oneccl     = ["dep:oneapi-rs"]
+collectives = ["nccl"]          # backward-compat alias for nccl
+```
+
+`worker/physical::replicated` (and the re-exported
+`ReplicatedDataWorker`) are gated on `any(feature = "nccl", feature =
+"oneccl")`, so either collective backend pulls the module in. The
+`collectives` alias is kept so existing CUDA callers that pass
+`--features collectives` keep working unchanged.
+
+## Test layout
+
+| Test | Scope | Gated on |
+|---|---|---|
+| `collectives::stub::tests` | sanity on the no-op impl | always |
+| `collectives::nccl::tests` | NCCL path, 2-GPU broadcast roundtrip | `feature = "testing-nccl"` |
+| `collectives::oneccl::tests::oneccl_worker` | child-process dispatcher — runs only when `ONECCL_TEST_RANK` is set in the env, otherwise returns silently. Reads `ONECCL_TEST_CASE` and dispatches to one of `worker_broadcast_1mb` / `worker_multi_region` / `worker_large_transfer`. | `feature = "oneccl"` (the parent module gate) |
+| `collectives::oneccl::tests::test_oneccl_broadcast_multi_xpu_raw` / `test_oneccl_multi_region_broadcast` / `test_oneccl_broadcast_large_transfer` | driver tests — each spawns one process per rank via `std::process::Command` re-entering the test binary with `ONECCL_TEST_RANK` set, distributes the bootstrap, and verifies 1 MB / multi-region / 64 MB broadcasts. | `feature = "testing-oneccl"` |
+
+The oneCCL tests use multi-process rendezvous because `ccl_rs_comm_create`
+requires distinct OS processes to exercise realistic behavior; in-process
+"ranks" share a single oneCCL runtime and would not catch KVS-address
+mismatch bugs. The dispatcher is gated only on `oneccl` so a child
+process spawned by the driver tests can find its handler at runtime
+without needing `testing-oneccl` re-enabled in the child build.

--- a/deps/0016-kvbm-v2-xpu-sycl-enablement/device_executor_flow.md
+++ b/deps/0016-kvbm-v2-xpu-sycl-enablement/device_executor_flow.md
@@ -1,0 +1,259 @@
+# Device Executor Flow — `transfer/executor/device.rs`
+
+Step-by-step flow for the transfer executor that dispatches through the
+`DeviceContextOps` / `DeviceStreamOps` / `DeviceMemPoolOps` trait surface
+(defined in [`lib/device/src/traits.rs`](../../device/src/traits.rs)).
+
+This document focuses on **what `device.rs` does at runtime**. For the
+architecture behind the traits and how XPU/SYCL fits in alongside CUDA,
+see [`kvbm_v2_xpu_sycl_enablement.md`](./kvbm_v2_xpu_sycl_enablement.md).
+
+The executor has three functions:
+
+| Function | Purpose |
+|---|---|
+| `execute_device_transfer` | Top-level dispatch: strategy + stream-pool selection + sync semantics |
+| `execute_whole_block_device` | FC→FC path: one `batch_copy` of `bytes_per_block` per block |
+| `execute_fc_lw_vectorized` | FC↔LW path: pool-backed pointer upload + `vectorized_copy` kernel launch |
+
+---
+
+## 1. `execute_device_transfer` — top-level dispatch
+
+Entered from `transfer::executor::execute_direct_transfer` for any
+`TransferStrategy` that is not `Memcpy` or NIXL.
+
+```mermaid
+flowchart TD
+    START([execute_device_transfer]) --> V1[Validate layer count<br/>+ outer dim match]
+    V1 --> V2[validate_layout_compatibility]
+    V2 --> LR[Resolve layer_range<br/>default = 0..num_layers]
+    LR --> SET[Compute flags:<br/>caller_manages_sync = device_stream.is_some&#40;&#41;<br/>whole_block = can_use_whole_block_transfer&#40;&#41;<br/>is_d2h = AsyncD2H or BlockingD2H]
+
+    SET --> CMS0{caller-provided<br/>device_stream?}
+    CMS0 -- yes --> USE_CALLER[Use caller stream]
+    CMS0 -- no + is_d2h --> POOL_D2H[ctx.next_d2h_stream]
+    CMS0 -- no + !is_d2h --> POOL_H2D[ctx.next_h2d_stream]
+
+    USE_CALLER --> DISPATCH
+    POOL_D2H --> DISPATCH
+    POOL_H2D --> DISPATCH
+
+    DISPATCH{whole_block?}
+    DISPATCH -- yes --> FN_WB[execute_whole_block_device]
+    DISPATCH -- no --> FN_VEC[execute_fc_lw_vectorized]
+
+    FN_WB --> BLK{Blocking strategy?<br/>BlockingH2D or BlockingD2H}
+    FN_VEC --> BLK
+
+    %% Phase 1: blocking sync runs unconditionally (independent of caller_managed)
+    BLK -- yes --> SYNC[device_stream.synchronize]
+    BLK -- no --> CMS1
+    SYNC --> CMS1
+
+    %% Phase 2: caller_managed early-return runs after the optional sync,
+    %% so a "Blocking + caller-provided stream" path also exits here.
+    CMS1{caller_manages_sync?}
+    CMS1 -- yes --> DONE_CMS([TransferCompleteNotification::completed])
+    CMS1 -- no --> ASY{Async* strategy?}
+
+    %% Phase 3: only the Async* branch records an event + registers.
+    %% Blocking* with no caller stream falls through to completed&#40;&#41;.
+    ASY -- yes --> EVT[device_stream.record_event]
+    EVT --> REG([ctx.register_device_event<br/>→ TransferCompleteNotification])
+    ASY -- no --> DONE_BLK([TransferCompleteNotification::completed])
+
+    style FN_WB fill:#4caf50,stroke:#2e7d32,color:#fff
+    style FN_VEC fill:#ff6b35,stroke:#c44520,color:#fff
+    style POOL_H2D fill:#90caf9,stroke:#1565c0
+    style POOL_D2H fill:#90caf9,stroke:#1565c0
+    style SYNC fill:#fff176,stroke:#f9a825
+```
+
+### Stream pool selection
+
+`TransferContext` maintains **two** stream pools per device, each
+`num_streams` wide, with round-robin acquisition:
+
+| Pool | Acquired via | Used for |
+|---|---|---|
+| H2D | `ctx.next_h2d_stream()` | Host→device (whole-block batch DMA *and* FC↔LW kernel launches) |
+| D2H | `ctx.next_d2h_stream()` | Device→host (whole-block *and* kernel) |
+
+This matches the upstream CUDA design. Both CUDA and SYCL queues are
+engine-class agnostic, so whole-block `batch_copy` and kernel
+`vectorized_copy` share the direction pool without losing concurrency.
+D2D maps to the H2D pool (`is_d2h = false`); the actual copy direction
+is determined by pointer addresses, not the pool label.
+
+On SYCL the pool is backed by round-robin `sycl::queue` slots. Every
+queue is built on the shared multi-device `SyclContext`
+(see `shared_sycl_context` in `lib/device/src/sycl/mod.rs`). Pool width is
+`TransferContext::num_streams` (default 4).
+
+### Sync semantics
+
+The executor runs three sequential phases after the copy is enqueued.
+Each phase is independent — the next phase always sees the side effects
+of the previous one.
+
+1. **Optional inline sync.** If the strategy is `BlockingH2D` /
+   `BlockingD2H`, call `device_stream.synchronize()`. This runs
+   regardless of whether the caller provided their own stream — a
+   `Blocking*` strategy always synchronizes inline before returning.
+2. **Caller-managed early exit.** If the caller provided their own
+   `device_stream`, return `TransferCompleteNotification::completed()`.
+   The caller owns synchronization for any further work; the executor
+   does not record an event on a caller-owned stream.
+3. **Async event registration.** Otherwise, if the strategy is
+   `AsyncH2D` / `AsyncD2H` / `AsyncD2D`, record a `DeviceEvent` on the
+   stream and hand it to `ctx.register_device_event`, which returns a
+   `TransferCompleteNotification` that completes when the event fires.
+   For `Blocking*` strategies that reach this phase (no caller stream,
+   already synchronized in phase 1), return `completed()` directly.
+
+---
+
+## 2. `execute_whole_block_device` — FC→FC path
+
+One pointer pair per block, one DMA per pair, direction auto-detected by
+the runtime from the pointer addresses.
+
+```mermaid
+flowchart TD
+    START([execute_whole_block_device]) --> CHK{num_blocks == 0?}
+    CHK -- yes --> DONE([return Ok])
+    CHK -- no --> BUILD["Build two host Vec&lt;u64&gt;:<br/>src_ptrs[i] = addr(src_block_ids[i], 0, 0)<br/>dst_ptrs[i] = addr(dst_block_ids[i], 0, 0)"]
+    BUILD --> COPY["stream.batch_copy(&src_ptrs, &dst_ptrs, bytes_per_block)"]
+    COPY --> LOG[tracing::debug num_blocks + bytes_per_block]
+    LOG --> DONE2([return Ok])
+
+    style COPY fill:#4caf50,stroke:#2e7d32,color:#fff
+```
+
+`bytes_per_block` comes from `src.layout().config().bytes_per_block()`.
+The source and destination layouts are both fully contiguous here, so
+one pointer per block is sufficient.
+
+`stream.batch_copy` is the `DeviceStreamOps::batch_copy` method: on CUDA
+it calls `kvbm_kernels::memcpy_batch` (using
+`cudaMemcpyBatchAsync` when available, falling back to a per-pair
+`cudaMemcpyAsync` loop); on SYCL it submits `num_pairs`
+`queue.memcpy_raw_async` calls, which the SYCL runtime auto-detects as
+H2D / D2H / D2D from the pointer addresses.
+
+---
+
+## 3. `execute_fc_lw_vectorized` — FC↔LW kernel path
+
+One pointer pair per (block, layer, outer) chunk. Pointer arrays are
+uploaded to device memory from a `DeviceMemPool`, then a GPU kernel
+reads them and performs `total_chunks` parallel copies of `chunk_size`
+bytes each.
+
+```mermaid
+flowchart TD
+    START([execute_fc_lw_vectorized]) --> CALC["Compute:<br/>chunk_size = page × inner × dtype_width<br/>total_chunks = num_blocks × num_layers × outer_dim"]
+    CALC --> CHK{total_chunks == 0?}
+    CHK -- yes --> DONE([return Ok])
+    CHK -- no --> S1["<b>Step 1</b>: build host Vec of u64<br/>src_ptrs, dst_ptrs — one per (block, layer, outer)<br/>with size-match assert per chunk"]
+
+    S1 --> S2["<b>Step 2</b>: pool.alloc_async × 2<br/>src_ptrs_device, dst_ptrs_device<br/>(stream-ordered on CUDA, software pool on SYCL)"]
+
+    S2 --> S3["<b>Step 3</b>: stream.memcpy_htod × 2<br/>upload pointer arrays H→D (async, stream-ordered)"]
+
+    S3 --> S4["<b>Step 4</b>: stream.record_event<br/>upload_event — fence after uploads only"]
+
+    S4 --> S5["<b>Step 5</b>: stream.vectorized_copy<br/>(src_ptrs_device, dst_ptrs_device, chunk_size, total_chunks)<br/>GPU kernel launch"]
+
+    S5 --> S6["<b>Step 6</b>: pool.free_async × 2<br/>stream-ordered free (CUDA) or event-deferred (SYCL)"]
+
+    S6 --> S7["<b>Step 7</b>: upload_event.synchronize<br/>wait H2D only — safe to drop host Vecs<br/>(does NOT wait for the kernel)"]
+
+    S7 --> LOG[tracing::debug total_chunks + chunk_size]
+    LOG --> DONE2([return Ok])
+
+    style S1 fill:#e0e0e0,stroke:#757575
+    style S2 fill:#64b5f6,stroke:#1565c0,color:#fff
+    style S3 fill:#ff8c5a,stroke:#c44520,color:#fff
+    style S4 fill:#fff176,stroke:#f9a825
+    style S5 fill:#ff6b35,stroke:#c44520,color:#fff
+    style S6 fill:#64b5f6,stroke:#1565c0,color:#fff
+    style S7 fill:#fff176,stroke:#f9a825
+```
+
+### Why record an event before the kernel
+
+Step 4 captures a fence immediately after the two `memcpy_htod` uploads.
+Step 7 waits on that event, which blocks only until the H2D copies are
+done — *not* until the kernel finishes. This lets the host drop the
+source `Vec<u64>` arrays as soon as the uploads complete, while the
+kernel keeps running asynchronously. The in-order stream (CUDA) or
+in-order `sycl::queue` (SYCL) guarantees the kernel still observes the
+uploads.
+
+### Backend specifics
+
+| Step | CUDA | SYCL |
+|---|---|---|
+| 2. `pool.alloc_async` | `CudaMemPool::alloc_async_raw` using `cuMemAllocFromPoolAsync` on the raw `CUstream` | `SyclMemPoolWrapper::alloc_async` draws from a software free-list over `sycl::malloc_device`; tracks ptr→size in `active_allocs` |
+| 3. `stream.memcpy_htod` | `cudarc::driver::result::memcpy_htod_async` | `queue.memcpy_raw_async` |
+| 4. `stream.record_event` | `stream.record_event(None)` | `queue.submit_barrier()` wrapped in `SyclEventWrapper` |
+| 5. `stream.vectorized_copy` | `kvbm_kernels::vectorized_copy` (`.cu` compiled by nvcc) | `kvbm_kernels::sycl_vectorized_copy` (`.cpp` compiled by `icpx -fsycl`) with the `sycl::queue*` handle. With the `xpu-sycl` feature **disabled**, the SYCL impl reads the device pointer arrays back to host and falls back to a `batch_copy` loop — slower, but lets the executor compile cleanly without `kvbm-kernels`'s SYCL launchers. |
+| 6. `pool.free_async` | `cuMemFreeAsync` stream-ordered | `SyclMemPoolWrapper` records the event and defers the return-to-pool until the event signals (`PendingFree` queue) |
+| 7. `event.synchronize` | `cuEventSynchronize` | `sycl::event::wait` |
+
+---
+
+## Relationship to the rest of the executor
+
+```mermaid
+flowchart LR
+    TM[TransferManager::execute_transfer] --> EXEC[execute_transfer<br/>in executor/mod.rs]
+    EXEC -->|Memcpy strategy| MEMCPY[memcpy executor]
+    EXEC -->|NixlRead / NixlWrite| NIXL[nixl executor]
+    EXEC -->|Async/Blocking H2D/D2H/D2D| DEV[execute_device_transfer<br/>this document]
+    DEV --> WB[execute_whole_block_device]
+    DEV --> VEC[execute_fc_lw_vectorized]
+
+    style DEV fill:#ff6b35,stroke:#c44520,color:#fff
+    style WB fill:#4caf50,stroke:#2e7d32,color:#fff
+    style VEC fill:#ff6b35,stroke:#c44520,color:#fff
+```
+
+- `memcpy` handles host↔host `Memcpy` (no device involved).
+- `nixl` handles any strategy whose name starts with `Nixl*` (RDMA / GDS).
+- `device.rs` handles everything device-local:
+  `AsyncH2D`, `AsyncD2H`, `AsyncD2D`, `BlockingH2D`, `BlockingD2H`.
+
+Two-hop transfers (e.g. Device → Pinned → Remote) land back in
+`execute_direct_transfer` once per hop, so each hop still flows through
+this executor independently.
+
+---
+
+## `TransferStrategy` vs. upstream — rename and additions
+
+The `TransferStrategy` enum consumed by this executor differs from
+upstream [`ai-dynamo/dynamo`](https://github.com/ai-dynamo/dynamo) `main`
+in two distinct ways:
+
+| Change | Upstream main | Branch | Rationale |
+|---|---|---|---|
+| **Rename** (no behavior change) | `CudaAsyncH2D`, `CudaAsyncD2H`, `CudaAsyncD2D` | `AsyncH2D`, `AsyncD2H`, `AsyncD2D` | These variants are dispatched by the backend-agnostic `device.rs`, which routes them to `CudaStreamWrapper` or `SyclStreamWrapper` through `DeviceStreamOps`. A `Cuda` prefix is misleading on the SYCL path, so the prefix is dropped. Behavior is identical — the rename is a pure find-and-replace. |
+| **New variants** | — (panics on `System ↔ Device`) | `BlockingH2D`, `BlockingD2H` | Upstream `strategy.rs` returns `panic!("System to Device transfers are not supported")` for `System ↔ Device(_)`. The branch replaces that panic with the new `Blocking*` strategies, which run an async copy on the stream and then call `device_stream.synchronize()` before returning. Applies on **both** backends — the motivating case (unpinned `System` memory degrading async copies to staged blocking behavior) affects CUDA and SYCL identically, so hiding the variants behind `#[cfg]` would leave the upstream panic in place for CUDA consumers with no benefit. |
+
+Semantics summary:
+
+- `Async*` — enqueues on a stream, records a `DeviceEvent`, returns a
+  notification. Caller awaits the notification. Applies to pinned host
+  memory or device memory.
+- `Blocking*` — enqueues on a stream, calls `device_stream.synchronize()`
+  inline, returns `TransferCompleteNotification::completed()`. Applies
+  to unpinned (`System`) host memory where the async copy would stage
+  internally and gain nothing from the notification path.
+- Neither form is backend-specific; both CUDA and SYCL stream wrappers
+  implement the same `DeviceStreamOps` contract.
+
+Nothing was removed from the upstream enum. The only removed *behavior*
+is the `panic!` on `System ↔ Device`, which is now a supported transfer.

--- a/deps/0016-kvbm-v2-xpu-sycl-enablement/event_sync.md
+++ b/deps/0016-kvbm-v2-xpu-sycl-enablement/event_sync.md
@@ -1,0 +1,231 @@
+# `event_sync_blocking` and layer-wise onboarding
+
+How the Python/FFI boundary in `kvbm-py3` synchronizes on device events
+coming from CUDA or SYCL, and how that pairs with
+`PhysicalWorker::execute_local_layerwise_onboard` on the Rust side.
+
+For architecture context — how this binding fits into KVBM v2 and why
+SYCL was added alongside CUDA — see
+[`kvbm_v2_xpu_sycl_enablement.md`](../../../kvbm-physical/docs/kvbm_v2_xpu_sycl_enablement.md).
+
+## What it is
+
+`event_sync_blocking(event_handle: u64) -> anyhow::Result<()>` is a
+single function with three cfg-gated bodies. It blocks the calling
+thread until the device event identified by `event_handle` fires.
+
+```rust
+// lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+
+#[cfg(feature = "cuda")]
+pub fn event_sync_blocking(event_handle: u64) -> anyhow::Result<()> {
+    unsafe {
+        let raw_event = event_handle as CUevent;
+        let result = cuEventSynchronize(raw_event);
+        if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+            return Err(anyhow::anyhow!(
+                "cuEventSynchronize failed with error: {:?}", result
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "xpu-sycl", not(feature = "cuda")))]
+pub fn event_sync_blocking(event_handle: u64) -> anyhow::Result<()> {
+    unsafe {
+        let raw_event = event_handle as *const oneapi_rs::sys::sycl_rs_event_t;
+        oneapi_rs::sys::sycl_rs_event_wait(raw_event)
+            .result()
+            .map_err(|e| anyhow::anyhow!("sycl_rs_event_wait failed: {:?}", e))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(feature = "cuda", feature = "xpu-sycl")))]
+pub fn event_sync_blocking(_event_handle: u64) -> anyhow::Result<()> {
+    anyhow::bail!("event_sync_blocking: no backend enabled (need cuda or xpu-sycl feature)")
+}
+```
+
+The `u64` handle is the numeric value of the underlying driver handle
+(`CUevent` or `sycl_rs_event_t*`) re-interpreted as an integer. vLLM
+passes handles across the Python/Rust boundary as opaque `u64`
+integers because it already owns the lifetime on the Python side.
+
+## The event pipeline
+
+A vLLM worker step with KVBM offload looks like this. The diagram is
+**high-level**: the actual path from a Python-side hook into
+`PhysicalWorker::execute_local_layerwise_onboard` goes through several
+engine-side intermediaries (worker-group dispatcher, transfer manager,
+etc.) that are elided here for clarity.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant vLLM as vLLM model runner
+    participant Py   as PyKvConnectorWorker<br/>(Python wrapper)
+    participant Rust as PyKvConnectorWorker<br/>(Rust impl)
+    participant PW   as PhysicalWorker<br/>(kvbm-engine)
+    participant Dev  as DeviceStream + DeviceEvent<br/>(kvbm-physical)
+
+    vLLM->>Py: register_kv_caches(caches, raw_event_handles)
+    Py->>Rust: self.layer_events = raw_event_handles (Vec<u64>)
+
+    Note over vLLM,PW: vLLM triggers an onboard via the connector —<br/>engine routes through to PhysicalWorker
+    vLLM->>PW: execute_local_layerwise_onboard(src, dst, layer_events)
+    loop for each layer
+        PW->>Dev: execute_transfer(layer_range = L..L+1, device_stream=H2D)
+        PW->>Dev: layer_events[L].record_on(&stream)
+    end
+
+    Note over vLLM,Rust: model runs forward pass, needs layer L's KV
+
+    loop vLLM forward pass
+        vLLM->>Py: save_kv_layer(layer_name)
+        Py->>Rust: self.layers_complete += 1
+        Note over Rust: when all layers complete,<br/>drain offload_ops
+        Rust->>Rust: event_sync_blocking(layer_events[last])?
+        Rust->>Rust: enqueue offload operations
+    end
+```
+
+The important bit: `event_sync_blocking` is called on the **last
+layer's event**, not on every layer. The whole point of recording per-layer
+events in `execute_local_layerwise_onboard` is that vLLM's attention can
+stream-wait on each event independently; KVBM only synchronizes the
+host-visible "all layers done" fence when it's about to enqueue G2→G3
+offload work that the GPU writes cannot racing against.
+
+## Error handling — why `?` matters
+
+The previous implementation used `assert_eq!(status, CUDA_SUCCESS)` and
+returned `()`. After the XPU enablement the signature changed to
+`Result<()>`, and the **vLLM connector** call site in `save_kv_layer`
+uses `?`:
+
+```rust
+// lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs:341
+event_sync_blocking(self.layer_events[self.layers_complete - 1])?;
+```
+
+A hook that drops the result would silently swallow failures — a
+driver-level event-wait error (bad handle, GPU hang, signal interrupt)
+would be lost. `?` ensures the error surfaces as an `anyhow::Error`
+up through the connector into vLLM, which logs it and fails the step
+rather than proceeding with stale KV.
+
+**Known caveat — TRT-LLM connector:** the equivalent call sites in
+[`trtllm_worker.rs:363, 540`](../src/block_manager/vllm/connector/trtllm_worker.rs)
+still drop the `Result` (no `?`). That's exactly the failure mode this
+section warns against and is worth tracking as a follow-up — until it
+uses `?`, event-wait errors on the TRT-LLM path are silently ignored.
+
+## How the event handle reaches Rust
+
+vLLM owns the events. On the Python side (in the vLLM connector) it
+creates one `torch.cuda.Event` (or `torch.xpu.Event`) per layer and
+passes the integer handle via the `bind_connector_metadata` pathway.
+Rust stores these in `self.layer_events: Vec<u64>` as raw integers —
+it never tries to reconstitute the Python object; it only ever calls
+`event_sync_blocking(handle)`.
+
+This keeps the boundary zero-copy and zero-ownership: KVBM does not
+own the events, does not destroy them, and can hand the same handles
+back to vLLM without reference counting on the Rust side.
+
+## Pairing with `DeviceEvent::record_on`
+
+On the Rust side, `PhysicalWorker::execute_local_layerwise_onboard`
+accepts `layer_events: &[Arc<DeviceEvent>]` — one `DeviceEvent` per
+layer, pre-allocated and re-recorded per iteration. The per-layer
+flow is:
+
+```rust
+// Source: lib/kvbm-engine/src/worker/physical.rs:323-340
+// (variable names match the actual function; some surrounding setup
+//  — handle / config lookup — elided for brevity)
+for layer in 0..num_layers {
+    let options = TransferOptions::builder()
+        .layer_range(layer..layer + 1)
+        .device_stream(stream.clone())
+        .build()?;
+    self.manager.execute_transfer(
+        g2_handle, src_block_ids,
+        g1_handle, dst_block_ids,
+        options,
+    )?;
+    layer_events[layer].record_on(&stream)?;
+}
+```
+
+`DeviceEvent::record_on` is the trait method that was added
+specifically to make this loop backend-agnostic — it re-records a
+pre-allocated event on the current position of a stream, matching
+CUDA's `cuEventRecord(event, stream)` semantics. The events vLLM hands
+in via `raw_event_handles` correspond 1:1 with these `DeviceEvent`s;
+both point at the same underlying CUDA / SYCL event object, because
+that's how Python and Rust share the handle.
+
+## Feature mutual exclusivity
+
+```toml
+# lib/bindings/kvbm/Cargo.toml
+cuda     = ["dep:cudarc"]
+xpu-sycl = ["dep:oneapi-rs"]
+nccl     = ["cuda", "block-manager", "dynamo-llm/nccl", "cudarc/nccl"]
+oneccl   = ["xpu-sycl", "block-manager"]
+```
+
+Note that enabling `nccl` activates NCCL features in *both* `dynamo-llm`
+and `cudarc` transitively (the `cudarc/nccl` and `dynamo-llm/nccl`
+entries). A future device backend that adds collective support should
+follow the same pattern: own a top-level feature and forward to the
+matching feature on each dependency that has its own collective gate.
+
+`cuda` and `xpu-sycl` are **not** marked mutually exclusive in
+`Cargo.toml`, but the source has three `pub fn event_sync_blocking`
+definitions gated on `cuda`, `xpu-sycl`, and `not(any(...))`. A
+`compile_error!` in
+[`src/block_manager/vllm/connector/worker.rs`](../src/block_manager/vllm/connector/worker.rs)
+rejects the `all(cuda, xpu-sycl)` combination at build time with a
+descriptive message:
+
+```rust
+#[cfg(all(feature = "cuda", feature = "xpu-sycl"))]
+compile_error!(
+    "Features `cuda` and `xpu-sycl` are mutually exclusive in kvbm-py3 bindings. \
+     Enable exactly one device backend."
+);
+```
+
+A `cargo build` with *no* device feature is still possible — it picks
+the "no backend enabled" stub that returns `bail!(...)`. The call site
+in `save_kv_layer` only runs `event_sync_blocking` after the *last*
+layer arrives (`if self.layers_complete == self.kv_cache_layers.len()`),
+so the failure surfaces at the final `save_kv_layer` of the request,
+not at the first layer onboard. Loud, but not the friendliest developer
+experience. Building `kvbm-py3` without `cuda` or `xpu-sycl` is never
+useful in production.
+
+## Two-liner runbook
+
+`nccl` and `oneccl` already imply `cuda` / `xpu-sycl` plus
+`block-manager` transitively, so the minimal feature set is just the
+collective name:
+
+- **vLLM on NVIDIA**: build `kvbm-py3` with `--features nccl`
+  (transitively pulls in `cuda` + `block-manager`).
+  `event_sync_blocking` binds to `cuEventSynchronize`; MLA broadcasts
+  go through `NcclCollectives`.
+- **vLLM on Intel XPU**: build `kvbm-py3` with `--features oneccl`
+  (transitively pulls in `xpu-sycl` + `block-manager`).
+  `event_sync_blocking` binds to `sycl_rs_event_wait`; MLA broadcasts
+  go through `OneCclCollectives`.
+
+## Related docs
+
+- [`device_executor_flow.md`](../../../kvbm-physical/docs/device_executor_flow.md) — how `DeviceEvent` is produced and recorded inside the executor.
+- [`collectives.md`](../../../kvbm-engine/docs/collectives.md) — how NCCL / oneCCL broadcasts interact with the same event machinery in the MLA worker.
+- [`sycl_pool_and_numa.md`](../../../memory/docs/sycl_pool_and_numa.md) — why the pinned host memory that backs `raw_event_handles`-associated buffers is allocated through a NUMA-pinned worker.

--- a/deps/0016-kvbm-v2-xpu-sycl-enablement/kvbm_v2_xpu_sycl_enablement.md
+++ b/deps/0016-kvbm-v2-xpu-sycl-enablement/kvbm_v2_xpu_sycl_enablement.md
@@ -1,0 +1,999 @@
+# KVBM v2 — XPU/SYCL enablement
+
+How Intel XPU (SYCL/oneAPI) was integrated into KVBM v2 alongside the
+existing NVIDIA CUDA backend: the trait surfaces that were extracted, the
+SYCL implementations that were added, and the crate-level wiring that keeps
+KVBM v2 engine-agnostic and framework-agnostic.
+
+This document covers the state of the branch, the evolution from the
+CUDA-only baseline, and the relationships between the crates under
+`lib/` that make up KVBM v2.
+
+## Related docs
+
+This doc is the overview. Per-crate details live alongside the code:
+
+- [`device_executor_flow.md`](./device_executor_flow.md) — device executor dispatch, `TransferStrategy` mapping, stream-pool walkthrough.
+- [`sycl_pool_and_numa.md`](../../memory/docs/sycl_pool_and_numa.md) — `SyclMemPool` free-list allocator and NUMA-aware pinned host pages.
+- [`sycl_kernels.md`](../../kvbm-kernels/docs/sycl_kernels.md) — SYCL kernel build pipeline, launcher ABI, `vectorized_copy` / permute kernel dispatch.
+- [`collectives.md`](../../kvbm-engine/docs/collectives.md) — NCCL / oneCCL multi-device sync, feature gating, test layout.
+- [`event_sync.md`](../../bindings/kvbm/docs/event_sync.md) — Python binding event-sync for layer-wise onboarding.
+
+## KVBM v2 modules and scope
+
+KVBM v2 is a set of Rust crates under `lib/` that together form an
+**engine-agnostic, framework-agnostic KV-cache block manager**. The goal is
+for any inference framework (vLLM, SGLang, TensorRT-LLM, …) to plug KVBM v2
+in under its own runtime, with no dependency flowing from KVBM into a
+specific framework.
+
+**Ownership per crate:**
+
+| Crate | Responsibility | XPU/SYCL in scope? |
+|---|---|---|
+| `kvbm-common` | Shared logical-tier vocabulary: `BlockId`, `SequenceHash`, `LogicalLayoutHandle` (G1/G2/G3/G4 tier enum). Pure data types, no device deps. | No — fully device-neutral. The `DeviceBackend` enum lives in `dynamo-device`, not here. |
+| `kvbm-config` | Static configuration for caches, discovery, NIXL, object storage, offload, onboard policies, tokio/rayon runtimes, messengers. Pure config structs. | No. |
+| `kvbm-logical` | Logical block lifecycle: registries, pools, sequence tracking, metrics, TinyLFU cache, pub/sub adapters, framework integrations. Works on logical handles; never touches devices directly. | No. |
+| `kvbm-consolidator` | Out-of-process aggregation/consolidation service. Reads event streams from KVBM workers via ZeroMQ (`tmq`), tracks events and hashes, emits to consumers. Operates on logical types (`BlockId`, `SequenceHash`) and serialized wire formats — never touches GPU memory. Deps: `kvbm-logical`, `dynamo-tokens`, `dynamo-kv-hashing`, `dynamo-kv-router`. | No. |
+| `dynamo-memory` (`lib/memory`) | Backend-agnostic storage primitives: `MemoryDescriptor`, `DeviceAllocator` / `PinnedAllocator` traits, `DeviceStorage` / `PinnedStorage`, `NumaWorkerPool`, `CudaMemPool`, `SyclMemPool`, plus NUMA helpers (`get_numa_node_for_pci_address`, `subdivide_cpu_set_for_device`, `enumerate_nvml_gpus`). Tier-1 Dynamo crate: **does not depend on any `kvbm-*` crate**. Backend-aware NUMA/CPU-set dispatch lives in `dynamo-device`, not here. | **Yes** — houses `SyclMemPool`, SYCL-aware sysfs primitives, and the allocator traits that downstream device wrappers implement. |
+| `dynamo-device` (`lib/device`) | Backend-agnostic device-handle abstraction: `DeviceBackend` tag enum (with inherent `is_available`/`detect_backend`/`list_available` probes), the `DeviceContextOps` / `DeviceStreamOps` / `DeviceEventOps` / `DeviceMemPoolOps` trait surface, the `DeviceContext` / `DeviceStream` / `DeviceEvent` / `DeviceMemPool` trait-object wrappers, the `CudaDeviceContext` / `SyclDeviceContext` impls, and `topology::get_device_cpu_set(backend, pci_address)` for backend-aware CPU-set dispatch. Tier-1 Dynamo crate: **does not depend on any `kvbm-*` crate** (one pre-existing exception: `kvbm-kernels` for kernel launchers — the kernels crate is misnamed and would be `dynamo-kernels` under the strict naming convention). | **Yes** — the canonical home for the multi-backend abstraction. CUDA and SYCL both implement the trait surface here. Adding ROCm or other backends is a single-crate change. |
+| `kvbm-kernels` | CUDA and SYCL kernel launchers: `vectorized_copy`, `memcpy_batch`, `sycl_vectorized_copy`, `sycl_*_from_block`. Built from `.cu` via nvcc and `.cpp` via `icpx -fsycl`. | **Yes** — SYCL kernel sources and FFI wrappers live here. |
+| `kvbm-physical` | KVBM-specific transfer subsystem: `TransferManager`, `TransferContext`, NIXL integration, layout/manager modules. Re-exports `dynamo_device as device` for backward compatibility, so `kvbm_physical::device::DeviceContext` continues to resolve. | **Yes** — the KVBM-side consumer of the multi-backend layer; transfer and NIXL routing are CUDA/SYCL-aware. |
+| `kvbm-engine` | Orchestrator: `InstanceLeader`, `PhysicalWorker`, `ReplicatedDataWorker`, sessions, offload pipeline, object tier (G4), `CollectiveOps` with NCCL and **oneCCL** implementations, `OneCclBootstrap`. | **Yes** — adds the `oneccl` feature and the XPU-aware layer-wise onboard path. |
+| `kvbm-py3` (`lib/bindings/kvbm`) | Python/FFI bindings consumed by external frameworks. Owns the vLLM connector and its backend-specific `event_sync_blocking` (CUDA / SYCL / fallback). | **Yes** — SYCL variant added alongside CUDA, mutually exclusive by feature. |
+
+**Shared logical-tier deps (referenced by KVBM but not part of it):**
+
+| Crate | Consumed by | Purpose | XPU/SYCL relevance |
+|---|---|---|---|
+| `dynamo-tokens` (`lib/tokens`) | `kvbm-common` (re-exported as `SequenceHash = dynamo_tokens::PositionalLineageHash`), `kvbm-logical`, `kvbm-consolidator` | Token block sequencing and `PositionalLineageHash` computation. No device deps. | No. |
+| `dynamo-kv-hashing` (`lib/kv-hashing`) | `kvbm-consolidator` | Prefix-aware KV hashing utilities. No device deps. | No. |
+| `dynamo-kv-router` (`lib/kv-router`) | `kvbm-consolidator` | Logical request routing across replicas. No device deps. | No. |
+| `dynamo-llm` (`lib/llm`) | `kvbm-py3` (`bindings/kvbm`) imports `block_manager::*` types: `BlockDataExt`, `Controller`, `DistributedLeaderWorkerResources`, `connector::protocol::RequestType`, `metrics_kvbm::KvbmMetrics`, `recorder::Recorder`. | No device deps. The `lib/llm/src/block_manager/v2/` subtree is not on the XPU/SYCL enablement path and should not receive new XPU work. | No. |
+| `dynamo-mocker` (`lib/mocker`) | None of the kvbm-* crates depend on it. Conversely, mocker's `kvbm-offload` feature (off by default) pulls in `kvbm-engine`, `kvbm-physical`, `kvbm-common`, `velo` for G1↔G2 offload simulation in test scenarios. | No device-specific code in the source; pure logical/test harness. | No. |
+
+The small crates (`kvbm-common`, `kvbm-config`, `kvbm-logical`,
+`kvbm-consolidator`) are listed for completeness but contain no
+device-specific code and are not touched by XPU/SYCL enablement. The
+diagrams in this document draw them as inert upper layers so the
+reader can see where KVBM v2 sits as a whole.
+
+## KVBM v2 crate stack
+
+This diagram shows the full KVBM v2 module stack under `lib/`, the
+dependency direction between crates, and the boundaries that external
+frameworks (vLLM, SGLang, …) integrate across. The device-specific
+implementations (CUDA / SYCL) sit at the bottom; logical/config/common
+crates at the top are framework-agnostic and have no device deps.
+
+```mermaid
+graph TB
+    subgraph ext["External frameworks (not in this repo)"]
+        VLLM["vLLM<br/>(via kvbm-py3 connector)"]
+        SGL["SGLang / TRT-LLM / …<br/>(future integrations)"]
+    end
+
+    subgraph v2["KVBM v2 (lib/)"]
+        subgraph topLayer["Tier-2 KVBM-specific (kvbm-* crates)"]
+            Common["kvbm-common<br/>BlockId, SequenceHash<br/>LogicalLayoutHandle (G1..G4)"]
+            Config["kvbm-config<br/>cache / offload / onboard<br/>discovery / messenger"]
+            Logical["kvbm-logical<br/>registries, pools, sequences<br/>TinyLFU, metrics, pubsub"]
+        end
+
+        subgraph midLayer["Orchestrator layer"]
+            Engine["kvbm-engine<br/>InstanceLeader, PhysicalWorker<br/>sessions, offload, G4 object tier<br/>CollectiveOps: NCCL + oneCCL"]
+        end
+
+        subgraph physLayer["KVBM transfer layer"]
+            Physical["kvbm-physical<br/>TransferManager, TransferContext<br/>NIXL integration<br/>(re-exports dynamo-device as 'device')"]
+            Kernels["kvbm-kernels<br/>CUDA: vectorized_copy, memcpy_batch<br/>SYCL: sycl_vectorized_copy, sycl_*_from_block"]
+        end
+
+        subgraph tier1Layer["Tier-1 Dynamo primitives (dynamo-* crates)"]
+            Device["dynamo-device<br/>DeviceBackend (Cuda / Sycl) + inherent probes<br/>Device{Context,Stream,Event,MemPool}Ops traits<br/>{Cuda,Sycl}DeviceContext impls<br/>topology::get_device_cpu_set"]
+            Memory["dynamo-memory<br/>MemoryDescriptor<br/>DeviceAllocator / PinnedAllocator traits<br/>DeviceStorage / PinnedStorage<br/>NumaWorkerPool, CudaMemPool, SyclMemPool<br/>get_numa_node_for_pci_address, enumerate_nvml_gpus"]
+        end
+
+        subgraph bindLayer["Bindings layer"]
+            PyBind["kvbm-py3 (lib/bindings/kvbm)<br/>Python extension module<br/>vLLM connector, event_sync_blocking"]
+        end
+
+        subgraph connectorLayer["Connector layer (upstream — ryan/kvbm-connector-merge, not on this branch)"]
+            Connector["kvbm-connector<br/>vLLM worker glue<br/>(today reaches cudarc::CudaEvent directly;<br/>future XPU enablement routes through dynamo-device)"]
+        end
+    end
+
+    subgraph hw["Device runtimes"]
+        CUDA["CUDA driver + cudarc"]
+        SYCL["SYCL / oneAPI (icpx)<br/>oneapi-rs bindings"]
+        NCCL["NCCL"]
+        OneCCL["oneCCL"]
+    end
+
+    %% External → bindings
+    VLLM -- "Python FFI" --> PyBind
+    SGL -. "future" .-> PyBind
+
+    %% Bindings → connector → engine (connector is the glue layer that
+    %% orchestrates everything; on this branch the bindings still talk
+    %% to engine directly)
+    PyBind -. on this branch .-> Engine
+    PyBind -. upstream .-> Connector
+    Connector --> Engine
+    Connector -. uses (today: raw cudarc::CudaEvent;<br/>future: DeviceEvent via dynamo-device) .-> Device
+
+    %% kvbm-logical depends only on dynamo-tokens (no kvbm-common/config dep).
+    %% kvbm-config depends on dynamo-memory (no kvbm-common dep).
+
+
+    %% Engine depends on logical, physical, dynamo-device (direct), and top layer
+    Engine --> Logical
+    Engine --> Physical
+    Engine --> Device
+    Engine --> Common
+    Engine --> Config
+
+    %% kvbm-physical sits above tier-1 Dynamo primitives
+    Physical --> Memory
+    Physical --> Device
+    Physical --> Common
+    Physical --> Kernels
+    Kernels -. optional .-> CUDA
+    Kernels -. optional .-> SYCL
+
+    %% dynamo-device owns the device abstraction; depends on dynamo-memory
+    %% for storage primitives (CudaMemPool / SyclMemPool / NUMA topology).
+    %% Crucially, dynamo-device does NOT depend on kvbm-common or any
+    %% other kvbm-* crate (one pre-existing exception: kvbm-kernels for
+    %% kernel launchers, flagged as a known wart).
+    Device --> Memory
+    Device -. cuda feature .-> CUDA
+    Device -. xpu-sycl feature .-> SYCL
+    Device -. via kvbm-kernels (pre-existing wart) ..-> Kernels
+
+    %% dynamo-memory is fully tier-1: no kvbm-* deps. cudarc is
+    %% unconditional (CudaMemPool); oneapi-rs is optional (SyclMemPool).
+    Memory -. optional (xpu-sycl feature) .-> SYCL
+    Memory --> CUDA
+
+    %% Collectives
+    Engine -. nccl feature .-> NCCL
+    Engine -. oneccl feature .-> OneCCL
+
+    %% Styling
+    classDef agnostic fill:#eceff1,stroke:#455a64,color:#000,stroke-width:2px
+    classDef orchestrator fill:#9c27b0,stroke:#6a1b9a,color:#fff,stroke-width:2px
+    classDef physical fill:#ff6b35,stroke:#c44520,color:#fff,stroke-width:2px
+    classDef kernels fill:#2196f3,stroke:#1565c0,color:#fff,stroke-width:2px
+    classDef memory fill:#4caf50,stroke:#2e7d32,color:#fff,stroke-width:2px
+    classDef bindings fill:#9e9e9e,stroke:#616161,color:#fff,stroke-width:2px
+    classDef connector fill:#bdbdbd,stroke:#424242,color:#000,stroke-width:2px,stroke-dasharray: 5 3
+    classDef external fill:#fff9c4,stroke:#f57f17,color:#000,stroke-width:2px
+    classDef hw fill:#cfd8dc,stroke:#37474f,color:#000,stroke-width:2px
+
+    class Common,Config,Logical agnostic
+    class Engine orchestrator
+    class Physical physical
+    class Kernels kernels
+    class Memory memory
+    class PyBind bindings
+    class Connector connector
+    class VLLM,SGL external
+    class CUDA,SYCL,NCCL,OneCCL hw
+```
+
+**Key takeaways for framework integration:**
+
+- **No upward dep from KVBM into a framework.** `kvbm-common`, `kvbm-config`,
+  and `kvbm-logical` have no knowledge of vLLM, PyTorch, or any inference
+  runtime. That's what makes v2 reusable across frameworks.
+- **One integration point: `kvbm-py3`.** External frameworks import the
+  Python extension module built from `lib/bindings/kvbm`, which internally
+  talks to `kvbm-engine`. Adding SGLang or TensorRT-LLM would mean a new
+  connector in the bindings crate (or a sibling Python binding) without
+  changes to the lower layers.
+- **Device/runtime is a compile-time feature, not a crate.** CUDA vs. XPU is
+  chosen via Cargo features (`cuda` / `xpu-sycl` on `kvbm-physical` and
+  `dynamo-memory`; `nccl` / `oneccl` on `kvbm-engine`). `kvbm-py3` enforces
+  that `cuda` and `xpu-sycl` are mutually exclusive.
+- **Kernels are optional and FFI-gated.** `kvbm-kernels` produces
+  `libkvbm_kernels.so` (nvcc) and `libkvbm_kernels_sycl.so` (icpx); both are
+  loaded only when the corresponding backend feature is enabled. SYCL
+  kernels are built automatically when the `xpu-sycl` Cargo feature is
+  enabled (icpx must be on PATH or `ONEAPI_ROOT` set).
+
+The remaining diagrams and tables zoom in on the **device abstraction** and
+**memory layer** inside this stack — the two layers that XPU/SYCL enablement
+actually touches.
+
+## Evolution: from CUDA-only to CUDA + XPU/SYCL
+
+Before this work, KVBM v2 assumed CUDA everywhere: device types, allocation,
+pools, collectives, pinned memory, and even test helpers called CUDA APIs
+directly. Enabling Intel XPU required extracting a small backend-agnostic
+trait surface at each boundary, then adding SYCL/oneAPI implementations
+behind it. The table below summarizes the shape of each boundary before and
+after XPU/SYCL enablement.
+
+| Area | Before (CUDA-only) | After (CUDA + XPU/SYCL) |
+|---|---|---|
+| **Backend selector** | Implicit — everything was CUDA. | `DeviceBackend::{Cuda, Sycl}` tag enum in `dynamo-device`. Runtime probes (`is_available` / `detect_backend` / `list_available`) are inherent methods on the enum, guarded by `catch_unwind` so a missing `libcuda.so` / `libsycl.so` doesn't abort the process. `DeviceContext::new(backend, id)` dispatches to `CudaDeviceContext` or `SyclDeviceContext` behind `#[cfg(feature = "cuda")]` / `#[cfg(feature = "xpu-sycl")]`. `dynamo-device` is a tier-1 Dynamo primitive: no `kvbm-*` deps, so non-KVBM consumers can use it directly. |
+| **Device context / stream / event** | Direct use of `cudarc::driver::{CudaContext, CudaStream, CudaEvent}`. | New traits `DeviceContextOps`, `DeviceStreamOps`, `DeviceEventOps`, `DeviceMemPoolOps` in `lib/device/src/traits.rs` (`dynamo-device`). `CudaDeviceContext` and `SyclDeviceContext` both implement them (named to avoid shadowing `cudarc::driver::CudaContext` and `oneapi_rs::safe::SyclContext`); the transfer executor, notification loop, and pool wrappers talk to trait objects only. `kvbm-physical` re-exports the crate as `kvbm_physical::device` for backward compatibility. |
+| **Copy API on streams** | Direction-named CUDA calls (`cudaMemcpyAsync` with explicit H2D/D2H kinds). | Pattern-based primitives on `DeviceStreamOps`: `batch_copy` (N DMAs, direction auto-detected), `memcpy_htod` / `memcpy_dtoh` (scalar uploads/downloads), `vectorized_copy` (kernel over pointer arrays). The executor picks between them based on op type, not direction. |
+| **`TransferStrategy` enum** | `CudaAsyncH2D`, `CudaAsyncD2H`, `CudaAsyncD2D`; `panic!` on `System ↔ Device`. | Two changes — (1) **rename** `CudaAsync*` → `Async*` since the backend-agnostic executor dispatches to either `CudaStreamWrapper` or `SyclStreamWrapper`; (2) **add** `BlockingH2D`, `BlockingD2H` that replace the upstream panic with an async copy + inline `device_stream.synchronize()`. Blocking variants apply on **both** backends because the motivating case (unpinned `System` memory degrading async copies to staged blocking behavior) affects CUDA and SYCL identically. See [`device_executor_flow.md`](./device_executor_flow.md#transferstrategy-vs-upstream--rename-and-additions) for the full before/after mapping. |
+| **Memory pool** | Native CUDA pool (`cuMemPoolCreate` / `cuMemAllocFromPoolAsync`). | Two pool implementations behind `DeviceMemPoolOps`: `CudaMemPool` (native API, stream-ordered) and `SyclMemPool` (software free-list over `sycl::malloc_device`, SYCL has no native pool API). `SyclMemPool`'s `PoolInner.active_allocs: HashMap<ptr, real_size>` keeps `cached_bytes` and `release_threshold` accurate when a best-fit returns a block larger than requested. |
+| **Device storage** | `DeviceStorage::new(size, device_id)` hard-coded to `cudarc::driver::result::malloc_sync`. | `DeviceStorage::new(size, Arc<dyn DeviceAllocator>)`. The new `DeviceAllocator` trait lives in `dynamo-memory` with *no* CUDA types; `DeviceContext` in `dynamo-device` implements it. The same pattern rewired `PinnedStorage`. |
+| **Pinned host allocation** | `PinnedStorage` called `cuMemHostAlloc` inline. | A `PinnedAllocator` trait in `dynamo-memory` is the per-backend FFI shim that `NumaWorkerPool` invokes from a NUMA-pinned worker thread (one thread per NUMA node, global singleton). `CudaPinnedAllocator` / `SyclPinnedAllocator` in `dynamo-device` provide the backend implementations; the worker first-touches pages after allocation so Linux binds them to the correct node. The NUMA-vs-fallback routing decision happens *upstream* of the trait, in `CudaDeviceContext::allocate_pinned` / `SyclDeviceContext::allocate_pinned`. End-to-end validation via `move_pages(2)` is available for either backend through the `validate_numa_placement` binary — see [`sycl_pool_and_numa.md`](../../memory/docs/sycl_pool_and_numa.md#validating-first-touch-on-real-hardware) for the correct invocation on CUDA vs. XPU hosts (XPU requires the `xpu-sycl` feature at build time). |
+| **NUMA topology / PCI discovery** | CUDA-specific: PCI BDF pulled from `cuDeviceGet*` attributes. | Backend-agnostic. `DeviceContextOps::pci_bdf_address()` returns `"DDDD:BB:DD.F"` — CUDA queries `CU_DEVICE_ATTRIBUTE_PCI_*`; SYCL reads `SyclDevice::info()?.pci_address`. NUMA-node lookup is split: `dynamo_memory::numa::get_numa_node_for_pci_address` resolves NUMA via sysfs with `nvidia-smi` / `xpu-smi` fallbacks (backend-agnostic; takes a PCI BDF string), while backend-aware CPU-set subdivision lives in `dynamo_device::topology::get_device_cpu_set(backend, pci)` — the latter dispatches per-backend GPU enumeration (NVML for CUDA, sysfs PCI scan for Intel `0x8086` class `0x03xxxx`) and calls back into `dynamo-memory`'s `subdivide_cpu_set_for_device` primitive for the actual splitting. |
+| **Event reuse** | Single-shot events — `CudaEvent::record(&stream)`. | New `DeviceEventOps::record_on_stream(stream_handle)` lets the same `DeviceEvent` be re-recorded on a later op. Required by `PhysicalWorker::execute_local_layerwise_onboard` in `kvbm-engine`, which records one event per layer on a shared H2D stream. |
+| **Kernels** | CUDA `.cu` sources compiled by nvcc in `kvbm-kernels`: `vectorized_copy`, `memcpy_batch`, optional permute kernels. | Same CUDA kernels, *plus* SYCL `.cpp` sources (`sycl/vectorized_copy_kernel.cpp`, `sycl/tensor_permute_kernel.cpp`) compiled by `icpx -fsycl` into `libkvbm_kernels_sycl.so` when `xpu-sycl` is enabled. FFI wrappers in `src/tensor_kernels_sycl.rs` expose them as `sycl_vectorized_copy`, `sycl_universal_from_block`, `sycl_block_from_universal`. SYCL kernels pass a `sycl::queue*` instead of a `cudaStream_t` and use byte-size element dispatch rather than dtype templates. |
+| **Collectives (`kvbm-engine`)** | NCCL only (`feature = "nccl"`, `cudarc::nccl`). | `CollectiveOps` trait is now implemented by `NcclCollectives` **and** `OneCclCollectives` (`feature = "oneccl"`, `oneapi-rs::ccl`). oneCCL supports both a from-scratch bootstrap (`OneCclBootstrap` — 8 B world_size + 256 B KVS address rendezvous) and borrowed handles from PyTorch / vLLM. Broadcasts use `ccl_rs_group_start/end` with a single `event_wait` on the last submitted op. |
+| **vLLM connector event sync (`kvbm-py3`)** | `event_sync_blocking(u64)` called `cuEventSynchronize` and asserted on failure. | Three cfg-gated implementations of the same `pub fn event_sync_blocking(u64) -> anyhow::Result<()>`: CUDA (`cuEventSynchronize`), SYCL (`oneapi_rs::sys::sycl_rs_event_wait`), and a "no backend" stub that `bail!`s. The call site now `?`-propagates the error instead of swallowing it. |
+| **Test helpers (`kvbm-physical`)** | Direct `cudaMemcpy` with explicit D2H/H2D kinds in `fill.rs` / `checksum.rs`. | Backend-agnostic `sync_memcpy_dtoh` / `sync_memcpy_htod` helpers on `DeviceContext` that construct a throwaway stream and synchronize. Tests pick a backend via `test_device_backend()` which prefers SYCL when compiled in and available, falling back to CUDA. |
+| **Benchmark tooling** | `bench_engine` and `bench_transfer` hard-coded `cuda_device_id`; `kvbench` was CUDA-only (no kernel-layer XPU baseline); no multi-rank collective bench. | Four tools, one per layer of the stack — kernel (`kvbench` / `kvbench_xpu_sycl`), TransferManager (`bench_transfer`), Leader/Worker (`bench_engine`), and a parallel cross-rank track for collective broadcast (`bench_collectives`, NCCL / oneCCL). See [Benchmarks](#benchmarks) below for the comparison. |
+
+The rest of the document shows the resulting trait surface, the full
+cross-crate graph, and the memory layer in detail.
+
+## Benchmarks
+
+KVBM v2 ships four benchmarks, each targeting a different layer of the
+stack. Running the progression bottom-up (kernel → transfer-manager →
+leader/worker, with collectives as a parallel cross-rank track) is the
+intended way to localize a performance regression: if the lower layer
+is clean but the higher layer regresses, the overhead lives in the
+layer between them.
+
+| Tool | Path | Layer | What it measures |
+|---|---|---|---|
+| `kvbench` / `kvbench_xpu_sycl` | [`lib/kvbm-kernels/examples/kvbench.rs`](../../kvbm-kernels/examples/kvbench.rs), [`lib/kvbm-kernels/examples/kvbench_xpu_sycl.rs`](../../kvbm-kernels/examples/kvbench_xpu_sycl.rs) | **Kernel layer** | Raw kernel vs. bare `memcpy` baseline. No `TransferManager`, no NIXL, no leader/worker. Compares `sycl_vectorized_copy` (FFI) against `sycl::queue::memcpy` (or `kvbm_kernels_launch_vectorized_copy` against `cudaMemcpyAsync` on CUDA) across `fc_to_fc` / `lw_to_fc` / `fc_to_lw` patterns and `d2d` / `h2d` / `d2h` directions. Llama 3.1 70B KV-cache dimensions, CSV output. |
+| `bench_transfer` | [`lib/kvbm-physical/examples/bench_transfer.rs`](../examples/bench_transfer.rs) | **TransferManager layer** | Same transfer matrix, but routed through `kvbm-physical::TransferManager` — the API the real offload path uses. Adds: stream-pool scheduling, executor dispatch (whole-block batch copy vs. FC↔LW vectorized kernel), NIXL registration. Backend selected via `--backend {auto,cuda,sycl}`. Still single-process. The delta vs. `kvbench` is the `TransferManager` overhead. |
+| `bench_engine` | [`lib/kvbm-engine/bin/bench_engine.rs`](../../kvbm-engine/bin/bench_engine.rs) | **Leader/Worker layer** | Production-fidelity end-to-end: `InstanceLeader` + `VeloWorkerService`/`Client` + `SpmdParallelWorkers`, NUMA-pinned worker threads (each with its own tokio runtime and `NixlAgent`), multi-GPU, optional full offload pipeline. `--backend {auto,cuda,sycl}`. NUMA affinity resolved via PCI BDF for both backends through the shared `get_device_cpu_set(backend_kind, bdf)` API. The delta vs. `bench_transfer` is leader/worker / offload-pipeline overhead. |
+| `bench_collectives` | [`lib/kvbm-engine/bin/bench_collectives.rs`](../../kvbm-engine/bin/bench_collectives.rs) | **Collectives layer** | Multi-process broadcast bandwidth for the cross-rank replication path. Rank 0 spawns one child per rank, distributes the bootstrap token, and collects JSONL. Reports decimal `alg_bw_gbps` / `bus_bw_gbps`. `--backend {nccl, oneccl}` selects NCCL (CUDA, raw `ncclBcast` on a `CudaStream`) or oneCCL (XPU, raw `ccl_rs_broadcast` on a `sycl::queue` via `OneCclBootstrap`). Sweeps `--sizes`, `--num-regions` (mirrors the production `broadcast_regions` group_start/group_end batch — `N = num_blocks × num_layers × outer_dim`), and `--no-wait-for-completion` to isolate stream-wait / `event::wait()` overhead. Complements `bench_engine` with replication-path numbers that the engine bench doesn't isolate. |
+
+All four produce CSV / JSONL output, so you can join runs and compare
+layers directly. See each tool's module-level docs for the exact flag
+matrix.
+
+## System overview — all crates and their abstractions
+
+The first diagram is the 10 000-foot view: which crate owns which abstraction
+and how components connect end-to-end. Each color is a single *layer of
+ownership*:
+
+- 🟩 **Green** — `dynamo-memory`: storage + allocator traits, NUMA worker pool, SYCL pool implementation.
+- 🟧 **Orange** — `dynamo-device`: device abstraction traits + CUDA / SYCL wrappers, backend tag enum, topology dispatch.
+- 🟥 **Red-orange** — `kvbm-physical`: KVBM transfer manager / context / executor (consumer of `dynamo-device`).
+- 🟦 **Blue** — `kvbm-kernels`: GPU kernel launchers (CUDA + SYCL).
+- 🟪 **Purple** — `kvbm-engine`: collective ops (NCCL + oneCCL) and workers that drive transfers.
+- Grey — `kvbm-py3` / vLLM binding layer.
+
+```mermaid
+graph TB
+    subgraph bindings["kvbm-py3 (bindings)"]
+        PyConnector["PyKvConnectorWorker"]
+        EvSync["event_sync_blocking(u64)<br/>cfg: cuda / xpu-sycl"]
+        PyConnector --> EvSync
+    end
+
+    subgraph engine["kvbm-engine"]
+        PW["PhysicalWorker<br/>execute_local_layerwise_onboard"]
+        CollTrait["trait CollectiveOps<br/>broadcast(layout, blocks, layers)"]
+        NcclImpl["NcclCollectives<br/>(feature = nccl)"]
+        OneCclImpl["OneCclCollectives<br/>(feature = oneccl)"]
+        OneCclBS["OneCclBootstrap<br/>KVS rendezvous"]
+        CollTrait -.-> NcclImpl
+        CollTrait -.-> OneCclImpl
+        OneCclImpl --> OneCclBS
+    end
+
+    subgraph device["dynamo-device (lib/device)"]
+        %% Trait + handle + Cuda/Sycl impls grouped per Ops surface
+        CtxOps["trait DeviceContextOps"]
+        DC["DeviceContext"]
+        CudaCtx["CudaDeviceContext / Wrappers<br/>device/cuda/mod.rs"]
+        SyclCtx["SyclDeviceContext / Wrappers<br/>device/sycl/mod.rs"]
+
+        StrOps["trait DeviceStreamOps"]
+        DS["DeviceStream"]
+
+        EvOps["trait DeviceEventOps"]
+        DE["DeviceEvent"]
+
+        PoolOps["trait DeviceMemPoolOps"]
+        DP["DeviceMemPool"]
+
+        DC -.-> CtxOps
+        DS -.-> StrOps
+        DE -.-> EvOps
+        DP -.-> PoolOps
+        CudaCtx -.implements.-> CtxOps
+        CudaCtx -.implements.-> StrOps
+        CudaCtx -.implements.-> EvOps
+        CudaCtx -.implements.-> PoolOps
+        SyclCtx -.implements.-> CtxOps
+        SyclCtx -.implements.-> StrOps
+        SyclCtx -.implements.-> EvOps
+        SyclCtx -.implements.-> PoolOps
+    end
+
+    subgraph physical["kvbm-physical"]
+        TM["TransferManager<br/>TransferContext<br/>stream pools × 2"]
+        Exec["execute_device_transfer<br/>whole-block vs FC↔LW"]
+
+        TM --> DC
+        TM --> Exec
+        Exec --> DS
+        Exec --> DP
+    end
+
+    subgraph kernels["kvbm-kernels"]
+        CudaKern["vectorized_copy<br/>memcpy_batch<br/>CUDA (.cu)"]
+        SyclKern["sycl_vectorized_copy<br/>sycl_*_from_block<br/>SYCL (.cpp via icpx)"]
+    end
+
+    subgraph memory["dynamo-memory"]
+        MD["trait MemoryDescriptor"]
+        DevS["DeviceStorage"]
+        PinS["PinnedStorage"]
+        DAlloc["trait DeviceAllocator"]
+        PAlloc["trait PinnedAllocator"]
+        NumaWP["NumaWorkerPool<br/>one thread per NUMA node"]
+        SMPool["SyclMemPool<br/>software free-list<br/>active_allocs: ptr→size"]
+        CMPool["CudaMemPool<br/>native pool API"]
+
+        DevS -.implements.-> MD
+        PinS -.implements.-> MD
+        DevS --> DAlloc
+        PinS --> DAlloc
+        NumaWP --> PAlloc
+    end
+
+    %% Cross-crate edges
+    PyConnector -. via DLPack .-> TM
+    PW --> TM
+    PW -. uses .-> CollTrait
+
+    NcclImpl -. raw CudaStream .-> CudaCtx
+    OneCclImpl -. raw sycl::queue .-> SyclCtx
+
+    CudaCtx -.implements.-> DAlloc
+    SyclCtx -.implements.-> DAlloc
+
+    CudaCtx -. owns inner .-> CudaPinAlloc["CudaPinnedAllocator<br/>cuMemHostAlloc"]
+    SyclCtx -. owns inner .-> SyclPinAlloc["SyclPinnedAllocator<br/>sycl::malloc_host"]
+    CudaPinAlloc -.implements.-> PAlloc
+    SyclPinAlloc -.implements.-> PAlloc
+    CudaCtx --> NumaWP
+    SyclCtx --> NumaWP
+
+    CudaCtx --> CMPool
+    SyclCtx --> SMPool
+    DP --> CMPool
+    DP --> SMPool
+
+    CudaCtx -. FFI .-> CudaKern
+    SyclCtx -. FFI .-> SyclKern
+
+    classDef mem fill:#4caf50,stroke:#2e7d32,color:#fff,stroke-width:2px
+    classDef dev fill:#ff9800,stroke:#e65100,color:#fff,stroke-width:2px
+    classDef phys fill:#ff6b35,stroke:#c44520,color:#fff,stroke-width:2px
+    classDef kern fill:#2196f3,stroke:#1565c0,color:#fff,stroke-width:2px
+    classDef eng fill:#9c27b0,stroke:#6a1b9a,color:#fff,stroke-width:2px
+    classDef bind fill:#9e9e9e,stroke:#616161,color:#fff,stroke-width:2px
+
+    class MD,DevS,PinS,DAlloc,PAlloc,NumaWP,SMPool,CMPool,CudaPinAlloc,SyclPinAlloc mem
+    class DC,DS,DE,DP,CudaCtx,SyclCtx,CtxOps,StrOps,EvOps,PoolOps dev
+    class TM,Exec phys
+    class CudaKern,SyclKern kern
+    class PW,CollTrait,NcclImpl,OneCclImpl,OneCclBS eng
+    class PyConnector,EvSync bind
+```
+
+### How a transfer flows through the stack
+
+1. A caller in `kvbm-engine` (e.g. `PhysicalWorker::execute_local_layerwise_onboard`)
+   asks `TransferManager::execute_transfer` for an onboard.
+2. `TransferContext` round-robins a `DeviceStream` out of the H2D or D2H
+   pool (`next_h2d_stream` / `next_d2h_stream`) and the executor
+   (`transfer::executor::device`) picks `batch_copy` (FC→FC) or
+   `vectorized_copy` (FC↔LW). Both whole-block DMAs and kernel launches
+   share the same direction pool; see `device_executor_flow.md` for the
+   rationale.
+3. `batch_copy` / `vectorized_copy` go through `DeviceStreamOps`, which
+   dispatches to either `CudaStreamWrapper` or `SyclStreamWrapper`.
+4. `vectorized_copy` implementations call into `kvbm-kernels`
+   (`kvbm_kernels::vectorized_copy` for CUDA, `kvbm_kernels::sycl_vectorized_copy`
+   for SYCL — the latter links against `libkvbm_kernels_sycl.so` built by
+   `icpx -fsycl`).
+5. Allocation flows the other way: `PhysicalLayout::builder().allocate_device(ctx)`
+   in `kvbm-physical` hands `DeviceStorage::new` an `Arc<dyn DeviceAllocator>`;
+   `DeviceStorage` lives in `dynamo-memory` and calls the trait.
+6. Pinned host allocation passes through `NumaWorkerPool` in `dynamo-memory`,
+   which runs a backend-specific `PinnedAllocator` on a NUMA-pinned worker
+   thread and first-touches pages before handing the pointer back.
+
+## Trait surface (drill-down)
+
+```mermaid
+classDiagram
+    direction TB
+
+    class DeviceBackend {
+        <<enum, in dynamo-device>>
+        Cuda
+        Sycl
+        +name() &'static str
+        +is_available() bool
+        +detect_backend() Result~Self~
+        +list_available() Vec~Self~
+    }
+
+    class DeviceContext {
+        -backend: DeviceBackend
+        -device_id: u32
+        -ops: Box~dyn DeviceContextOps~
+        +new(backend, device_id) Result~Self~
+        +pci_bdf_address() Option~String~
+        +create_stream() Result~DeviceStream~
+        +allocate_device(size) Result~u64~
+        +free_device(ptr) Result
+        +allocate_pinned(size) Result~u64~
+        +free_pinned(ptr) Result
+        +create_memory_pool(reserve, threshold) Result~DeviceMemPool~
+    }
+
+    class DeviceStream {
+        -backend: DeviceBackend
+        +ops: Box~dyn DeviceStreamOps~
+        +batch_copy(src, dst, size) Result
+        +memcpy_htod(dst_device, src_host) Result
+        +memcpy_dtoh(src_device, dst_host) Result
+        +vectorized_copy(src_dev, dst_dev, chunk, count) Result
+        +record_event() Result~DeviceEvent~
+        +synchronize() Result
+    }
+
+    class DeviceEvent {
+        -backend: DeviceBackend
+        +ops: Box~dyn DeviceEventOps~
+        +is_complete() Result~bool~
+        +synchronize() Result
+        +record_on(stream: DeviceStream) Result
+    }
+
+    class DeviceMemPool {
+        -backend: DeviceBackend
+        -ops: Box~dyn DeviceMemPoolOps~
+        +alloc_async(size, stream) Result~u64~
+        +free_async(ptr, stream) Result
+    }
+
+    %% --- Context group: trait + handle + Cuda/Sycl impls -----------------
+    class DeviceContextOps {
+        <<trait>>
+        +device_id() u32
+        +create_stream() Result~Box dyn DeviceStreamOps~
+        +allocate_device(size) Result~u64~
+        +free_device(ptr) Result
+        +allocate_pinned(size) Result~u64~
+        +free_pinned(ptr) Result
+        +bind_to_thread() Result*
+        +disable_event_tracking() Result*
+        +create_memory_pool(reserve, threshold) Result~Box dyn DeviceMemPoolOps~
+        +raw_handle() Option~u64~*
+        +pci_bdf_address() Option~String~*
+    }
+
+    class CudaDeviceContext {
+        <<cuda backend>>
+        +create_stream() CudaStreamWrapper
+        +allocate_device()
+        +allocate_pinned() NUMA-aware
+        +create_memory_pool() CudaMemPoolWrapper
+        +pci_bdf_address()
+    }
+
+    class SyclDeviceContext {
+        <<xpu backend>>
+        -device: Arc<SyclDevice>
+        -shared_context: Arc<SyclContext>
+        +create_stream() fresh SyclQueue each call
+        +allocate_device() tracked
+        +allocate_pinned() NUMA-aware
+        +create_memory_pool() SyclMemPoolWrapper
+        +pci_bdf_address()
+    }
+
+    %% --- Stream group ----------------------------------------------------
+    class DeviceStreamOps {
+        <<trait>>
+        +batch_copy(src, dst, size) Result
+        +memcpy_htod(dst_device, src_host) Result
+        +memcpy_dtoh(src_device, dst_host) Result
+        +vectorized_copy(src_dev, dst_dev, chunk, count) Result
+        +record_event() Result~Box dyn DeviceEventOps~
+        +synchronize() Result
+        +raw_handle() Option~u64~*
+    }
+
+    class CudaStreamWrapper {
+        <<cuda backend>>
+        +batch_copy()
+        +memcpy_htod()
+        +memcpy_dtoh()
+        +vectorized_copy() kernel via kvbm-kernels
+        +record_event() CudaEventWrapper
+    }
+
+    class SyclStreamWrapper {
+        <<xpu backend>>
+        +batch_copy()
+        +memcpy_htod()
+        +memcpy_dtoh()
+        +vectorized_copy() SYCL kernel via kvbm-kernels
+        +record_event() SyclEventWrapper barrier
+    }
+
+    %% --- Event group -----------------------------------------------------
+    class DeviceEventOps {
+        <<trait>>
+        +is_complete() Result~bool~
+        +synchronize() Result
+        +record_on_stream(stream_handle: u64) Result
+        +raw_handle() Option~u64~*
+    }
+
+    class CudaEventWrapper {
+        <<cuda backend>>
+        +is_complete()
+        +synchronize()
+        +record_on_stream()
+    }
+
+    class SyclEventWrapper {
+        <<xpu backend>>
+        +is_complete()
+        +synchronize()
+        +record_on_stream()
+    }
+
+    %% --- MemPool group ---------------------------------------------------
+    class DeviceMemPoolOps {
+        <<trait>>
+        +alloc_async(size, stream) Result~u64~
+        +free_async(ptr, stream) Result
+    }
+
+    class CudaMemPoolWrapper {
+        <<cuda backend>>
+        -pool: CudaMemPool
+        +alloc_async() stream-ordered
+        +free_async()
+    }
+
+    class SyclMemPoolWrapper {
+        <<xpu backend>>
+        -pool: SyclMemPool
+        -buffers: Mutex~HashMap~u64, usize~~
+        -pending_frees: Mutex~Vec~PendingFree~~
+        +alloc_async()
+        +free_async() event-deferred
+    }
+
+    %% --- Allocator (dynamo-memory consumer-tier trait) -------------------
+    class DeviceAllocator {
+        <<trait in dynamo-memory>>
+        +allocate_device(size) Result~u64~
+        +free_device(ptr) Result
+        +allocate_pinned(size) Result~u64~
+        +free_pinned(ptr) Result
+        +device_id() u32
+    }
+
+    %% Public-handle composition (handle owns Box<dyn Ops>)
+    DeviceContext --> DeviceBackend : has
+    DeviceContext *-- DeviceContextOps : ops
+    DeviceContext ..> DeviceStream : creates
+    DeviceContext ..> DeviceMemPool : creates
+    DeviceContext ..|> DeviceAllocator : implements
+
+    DeviceStream --> DeviceBackend : has
+    DeviceStream *-- DeviceStreamOps : ops
+    DeviceStream ..> DeviceEvent : creates
+
+    DeviceEvent --> DeviceBackend : has
+    DeviceEvent *-- DeviceEventOps : ops
+
+    DeviceMemPool --> DeviceBackend : has
+    DeviceMemPool *-- DeviceMemPoolOps : ops
+
+    %% Trait factory relations (Ops creates Ops)
+    DeviceContextOps ..> DeviceStreamOps : creates
+    DeviceContextOps ..> DeviceMemPoolOps : creates
+    DeviceStreamOps ..> DeviceEventOps : creates
+
+    %% Backend impls — grouped with their Ops trait above
+    CudaDeviceContext ..|> DeviceContextOps : implements
+    SyclDeviceContext ..|> DeviceContextOps : implements
+
+    CudaStreamWrapper ..|> DeviceStreamOps : implements
+    SyclStreamWrapper ..|> DeviceStreamOps : implements
+
+    CudaEventWrapper ..|> DeviceEventOps : implements
+    SyclEventWrapper ..|> DeviceEventOps : implements
+
+    CudaMemPoolWrapper ..|> DeviceMemPoolOps : implements
+    SyclMemPoolWrapper ..|> DeviceMemPoolOps : implements
+
+    style DeviceAllocator fill:#4caf50,stroke:#2e7d32,color:#fff,stroke-width:3px
+    style DeviceContext fill:#fff3e0,stroke:#ef6c00,stroke-width:3px
+
+    style DeviceStreamOps fill:#ff6b35,stroke:#c44520,color:#fff,stroke-width:3px
+    style DeviceStream fill:#ff8c5a,stroke:#c44520,color:#fff,stroke-width:2px
+    style CudaStreamWrapper fill:#ffb088,stroke:#c44520,stroke-width:2px
+    style SyclStreamWrapper fill:#ffb088,stroke:#c44520,stroke-width:2px
+
+    style DeviceEventOps fill:#9c27b0,stroke:#6a1b9a,color:#fff,stroke-width:2px
+
+    style DeviceMemPoolOps fill:#2196f3,stroke:#1565c0,color:#fff,stroke-width:3px
+    style DeviceMemPool fill:#64b5f6,stroke:#1565c0,color:#fff,stroke-width:2px
+    style CudaMemPoolWrapper fill:#90caf9,stroke:#1565c0,stroke-width:2px
+    style SyclMemPoolWrapper fill:#90caf9,stroke:#1565c0,stroke-width:2px
+```
+
+## Memory layer (`dynamo-memory`)
+
+The storage side is deliberately separated from the device abstraction so
+`dynamo-memory` stays free of device-SDK deps. Storage types expose themselves
+as `MemoryDescriptor` (size, address, storage kind, optional NIXL descriptor)
+and delegate allocation to a backend-agnostic `DeviceAllocator`. Pinned host
+memory additionally goes through a NUMA worker pool that owns a
+`PinnedAllocator` per backend.
+
+```mermaid
+classDiagram
+    direction TB
+
+    %% --- Storage descriptor group (dynamo-memory) ----------------------
+    class MemoryDescriptor {
+        <<trait>>
+        +addr() usize
+        +size() usize
+        +storage_kind() StorageKind
+        +as_any() Any
+        +nixl_descriptor() Option~NixlDescriptor~
+    }
+
+    class StorageKind {
+        <<enum>>
+        System
+        Pinned
+        Device(u32)
+        Disk(u64)
+    }
+
+    class DeviceStorage {
+        -ctx: Arc~dyn DeviceAllocator~
+        -ptr: u64
+        -device_id: u32
+        -len: usize
+        +new(len, ctx) Result~Self~
+    }
+
+    class PinnedStorage {
+        -ctx: Arc~dyn DeviceAllocator~
+        -ptr: usize
+        -len: usize
+        +new(len, ctx) Result~Self~
+    }
+
+    class SystemStorage {
+        +new(len) Result~Self~
+    }
+
+    class DiskStorage {
+        +new(len) Result~Self~
+    }
+
+    %% --- Allocator traits (dynamo-memory) + impls (dynamo-device) ------
+    class DeviceAllocator {
+        <<trait, dynamo-memory>>
+        +allocate_device(size) Result~u64~
+        +free_device(ptr) Result
+        +allocate_pinned(size) Result~u64~
+        +free_pinned(ptr) Result
+        +device_id() u32
+    }
+
+    class DeviceContext {
+        <<dynamo-device>>
+        implements DeviceAllocator
+    }
+
+    class PinnedAllocator {
+        <<trait, dynamo-memory>>
+        +alloc_pinned(size) Result~*mut u8~
+        +free_pinned(ptr) Result
+    }
+
+    class CudaPinnedAllocator {
+        <<dynamo-device>>
+        -context: Arc~cudarc::CudaContext~
+        +alloc_pinned() cuMemHostAlloc
+    }
+
+    class SyclPinnedAllocator {
+        <<dynamo-device>>
+        -context: Arc<SyclContext>
+        +alloc_pinned() sycl::malloc_host
+    }
+
+    %% --- NUMA worker pool group (dynamo-memory) ------------------------
+    class NumaWorkerPool {
+        <<singleton, dynamo-memory>>
+        +global() &static Self
+        +allocate_pinned_for_gpu(size, pci_bdf, allocator) Result~Option~*mut u8~~
+        +allocate_pinned_on_node(size, node, allocator) Result
+    }
+
+    class NumaWorker {
+        -node: NumaNode
+        -thread: pinned via sched_setaffinity
+        +allocate(size, allocator) Result
+    }
+
+    %% --- Device-side memory pools (dynamo-memory) ----------------------
+    class CudaMemPool {
+        -inner: Mutex~CUmemoryPool~
+        +alloc_async_raw(size, stream) Result
+        +free_async_raw(ptr, stream) Result
+    }
+
+    class SyclMemPool {
+        -context: Arc~SyclContext~
+        -device: Arc~SyclDevice~
+        -inner: Mutex~PoolInner~
+        -release_threshold: u64
+        +alloc(size) Result~u64~
+        +free(ptr, size) Result
+    }
+
+    class PoolInner {
+        -free_list: BTreeMap~size, Vec~FreeBlock~~
+        -active_allocs: HashMap~ptr, real_size~
+        -cached_bytes: usize
+    }
+
+    %% --- Storage → MemoryDescriptor implements -------------------------
+    SystemStorage ..|> MemoryDescriptor
+    DiskStorage ..|> MemoryDescriptor
+    DeviceStorage ..|> MemoryDescriptor
+    PinnedStorage ..|> MemoryDescriptor
+    MemoryDescriptor ..> StorageKind : returns
+
+    %% --- Storage → DeviceAllocator (Arc dyn) ---------------------------
+    DeviceStorage --> DeviceAllocator : Arc dyn
+    PinnedStorage --> DeviceAllocator : Arc dyn
+
+    %% --- Allocator impls (kept adjacent to their trait) ----------------
+    DeviceContext ..|> DeviceAllocator : implements
+    CudaPinnedAllocator ..|> PinnedAllocator : implements
+    SyclPinnedAllocator ..|> PinnedAllocator : implements
+
+    %% --- NUMA worker pool wiring ---------------------------------------
+    NumaWorkerPool *-- NumaWorker : per-node
+    NumaWorker --> PinnedAllocator : calls dyn
+
+    DeviceContext ..> NumaWorkerPool : allocate_pinned
+    DeviceContext ..> CudaPinnedAllocator : wraps
+    DeviceContext ..> SyclPinnedAllocator : wraps
+
+    %% --- Memory pools ---------------------------------------------------
+    SyclMemPool *-- PoolInner
+    DeviceContext ..> CudaMemPool : create_memory_pool
+    DeviceContext ..> SyclMemPool : create_memory_pool
+
+    %% --- Styling --------------------------------------------------------
+    style MemoryDescriptor fill:#66bb6a,stroke:#2e7d32,color:#fff,stroke-width:2px
+    style DeviceAllocator fill:#4caf50,stroke:#2e7d32,color:#fff,stroke-width:3px
+    style PinnedAllocator fill:#4caf50,stroke:#2e7d32,color:#fff,stroke-width:3px
+    style NumaWorkerPool fill:#81c784,stroke:#2e7d32,color:#fff,stroke-width:2px
+    style CudaMemPool fill:#81c784,stroke:#2e7d32,color:#fff,stroke-width:2px
+    style SyclMemPool fill:#81c784,stroke:#2e7d32,color:#fff,stroke-width:2px
+    style DeviceContext fill:#ffb088,stroke:#c44520,stroke-width:3px,color:#000
+    style CudaPinnedAllocator fill:#ffccbc,stroke:#c44520
+    style SyclPinnedAllocator fill:#ffccbc,stroke:#c44520
+```
+
+Key points:
+
+- **`MemoryDescriptor`** is the only type-erasable trait — everything downstream
+  (layouts, NIXL registration) handles `Arc<dyn MemoryDescriptor>`.
+- **`DeviceAllocator`** and **`PinnedAllocator`** are both backend-agnostic
+  traits owned by `dynamo-memory`. The `DeviceContext` in `dynamo-device`
+  implements `DeviceAllocator` directly; small `CudaPinnedAllocator` /
+  `SyclPinnedAllocator` shim structs in `dynamo-device` implement
+  `PinnedAllocator` so the NUMA worker pool can dispatch backend-specific
+  FFI from a node-pinned thread.
+- **`NumaWorkerPool`** is a process-global singleton. It never does backend
+  calls itself — it just hands a `PinnedAllocator` to a NUMA-pinned worker
+  thread, which does the allocation and first-touches each page.
+- **`SyclMemPool`** is the only software memory pool in the tree. `PoolInner`
+  keeps `active_allocs: HashMap<ptr, real_size>` so that a best-fit reuse that
+  returns a larger block doesn't corrupt `cached_bytes` or the
+  `release_threshold` budget when the caller later frees with a smaller size
+  hint. The CUDA pool uses the native CUDA pool APIs and needs none of this.
+
+## Key design decisions
+
+### Backend selection
+
+`DeviceBackend` lives in `dynamo-device` — a tier-1 Dynamo primitive
+crate that does not depend on any `kvbm-*` crate. Runtime availability
+probes are inherent methods on the enum (no extension trait), guarded
+by `catch_unwind` so a missing `libcuda.so` or `libsycl.so` does not
+abort the process.
+
+```rust
+// dynamo-device
+pub enum DeviceBackend { Cuda, Sycl }
+impl DeviceBackend {
+    pub fn name(&self) -> &'static str;       // "CUDA" / "SYCL (XPU)"
+    pub fn is_available(&self) -> bool;       // catch_unwind FFI probe
+    pub fn detect_backend() -> Result<Self>;  // Cuda-first, then Sycl
+    pub fn list_available() -> Vec<Self>;
+}
+```
+
+`DeviceContext::new(backend, device_id)` dispatches to
+`CudaDeviceContext::new` or `SyclDeviceContext::new` behind
+`#[cfg(feature = "cuda")]` / `#[cfg(feature = "xpu-sycl")]`.
+
+**Crate-tier rule.** `dynamo-*` crates are subsystem-agnostic
+primitives; `kvbm-*` crates depend on them, never the reverse. Adding
+ROCm or another backend is a single-crate change inside `dynamo-device`
+(append a `Rocm` variant, add a `rocm` Cargo feature, gate a `rocm`
+submodule with the FFI impl). KVBM downstreams (`kvbm-physical`,
+`kvbm-engine`, bindings) automatically gain the new backend through
+the existing trait surface.
+
+### Copy API — pattern-based, not direction-based
+
+Three primitives on `DeviceStreamOps`:
+
+- **`batch_copy(src_ptrs, dst_ptrs, size)`** — N independent DMA copies of the
+  same size. Direction (H2D, D2H, D2D) is auto-detected from pointer addresses
+  by the runtime (`cudaMemcpyDefault` / SYCL `queue.memcpy()`). Used for
+  whole-block FC→FC transfers.
+- **`memcpy_htod(dst_device, src_host)`** / **`memcpy_dtoh(src_device, dst_host)`** —
+  stream-ordered scalar copies used to upload/download pointer arrays for
+  `vectorized_copy` and by the backend-agnostic `sync_memcpy_*` test helpers.
+- **`vectorized_copy(src_ptrs_device, dst_ptrs_device, chunk_size, count)`** —
+  N independent copies executed in parallel by a GPU kernel. Both pointer
+  arrays live in device memory (previously uploaded via `memcpy_htod`).
+  Implemented by `kvbm-kernels` for CUDA (`kvbm_kernels_launch_vectorized_copy`)
+  and SYCL (`kvbm_kernels_sycl_launch_vectorized_copy` in
+  `sycl/vectorized_copy_kernel.cpp`). Used for FC↔LW per-chunk transfers.
+
+The executor picks `batch_copy` or `vectorized_copy` based purely on
+layout shape (whole-block vs. FC↔LW); callers don't choose.
+
+### Stream pools
+
+`TransferContext` creates **two** stream pools per device — one for H2D and
+one for D2H — each `num_streams` wide (default 4) with round-robin
+acquisition. Whole-block DMAs and kernel launches share the same direction
+pool; neither CUDA nor SYCL binds queues to distinct engine classes today,
+so splitting copy vs. compute into separate pools gave no concurrency
+benefit. The two-pool layout matches upstream `ai-dynamo/dynamo` CUDA.
+
+On SYCL, `SyclDeviceContext::create_stream()` returns a fresh in-order
+`sycl::queue` on each call — the stream pool lives entirely in
+`TransferContext` (matching the CUDA shape). Every queue kvbm-physical
+hands out is bound to the shared multi-device `SyclContext`. Pool width is
+`TransferContext::num_streams` (default 4).
+
+### Events
+
+`DeviceEventOps` now includes `record_on_stream(stream_handle)` so a single
+event can be re-recorded across successive ops — used by
+`PhysicalWorker::execute_local_layerwise_onboard` in `kvbm-engine`, which
+records one event per layer on a shared H2D stream so the caller can
+stream-wait per-layer.
+
+### Memory pool
+
+`DeviceMemPoolOps::{alloc_async, free_async}` take a `&dyn DeviceStreamOps`
+for stream ordering.
+
+- **CUDA**: `CudaMemPoolWrapper` uses `cuMemAllocFromPoolAsync` /
+  `cuMemFreeAsync` with the raw `CUstream` handle — GPU-side ordering is
+  implicit.
+- **SYCL**: SYCL has no native pool API. `SyclMemPoolWrapper` wraps
+  `dynamo_memory::SyclMemPool` (a software free-list over
+  `sycl::malloc_device`). `free_async` defers the return-to-pool behind a
+  recorded `DeviceEvent` via `pending_frees`; the deferred frees are drained
+  on the next `alloc_async`. The inner `SyclMemPool` tracks every outstanding
+  ptr → real allocated size in `active_allocs`, so reusing a larger block for
+  a smaller request does not corrupt `cached_bytes` / `release_threshold`.
+
+### PCI BDF for NUMA discovery
+
+`DeviceContextOps::pci_bdf_address()` returns the device's PCI BDF as a
+`"DDDD:BB:DD.F"` string — CUDA queries `CU_DEVICE_ATTRIBUTE_PCI_*`; SYCL
+reads `SyclDevice::info()?.pci_address`. `dynamo_memory::numa` consumes this
+to pick a NUMA node via sysfs (`/sys/bus/pci/devices/<bdf>/numa_node`), with
+`nvidia-smi` / `xpu-smi` fallbacks.
+
+### Allocation bridging
+
+The `dynamo-memory` crate no longer depends on any device SDK for the
+storage abstraction. Instead it defines:
+
+```rust
+pub trait DeviceAllocator: Send + Sync + Debug {
+    fn allocate_device(&self, size: usize) -> Result<u64>;
+    fn free_device(&self, ptr: u64) -> Result<()>;
+    fn allocate_pinned(&self, size: usize) -> Result<u64>;
+    fn free_pinned(&self, ptr: u64) -> Result<()>;
+    fn device_id(&self) -> u32;
+}
+```
+
+`DeviceContext` in `dynamo-device` implements this trait, and both
+`DeviceStorage::new(size, Arc<dyn DeviceAllocator>)` and
+`PinnedStorage::new(size, Arc<dyn DeviceAllocator>)` accept it. This keeps
+backend-specific FFI out of `dynamo-memory`'s public API surface while letting the
+physical-layout builder allocate through whichever backend was selected at
+`TransferManager` construction time.
+
+### NUMA-aware pinned allocation
+
+`dynamo_memory::numa::worker_pool::NumaWorkerPool` is a global lazy pool
+of threads, one per NUMA node, each pinned with `sched_setaffinity`. Host
+memory is allocated via a backend-specific `PinnedAllocator`:
+
+```rust
+pub trait PinnedAllocator: Send + Sync + 'static {
+    fn alloc_pinned(&self, size: usize) -> Result<*mut u8, String>;
+    fn free_pinned(&self, ptr: *mut u8) -> Result<(), String>;
+}
+```
+
+`CudaPinnedAllocator` (in `lib/device/src/cuda/mod.rs`, the `dynamo-device`
+crate) binds the CUDA context to the pinned worker thread before calling
+`cuMemHostAlloc`. `SyclPinnedAllocator` (in `lib/device/src/sycl/mod.rs`)
+calls `context.malloc_host(size)` — allocation is context-scoped, so no
+queue or thread binding is needed. After the backend allocation returns,
+the worker writes one byte per page to force first-touch on the correct
+node.
+
+### Collectives
+
+A parallel trait `CollectiveOps` lives in `kvbm-engine`:
+
+- **`NcclCollectives`** — CUDA via `cudarc::nccl`.
+- **`OneCclCollectives`** — SYCL via `oneapi-rs::ccl`. Broadcasts use
+  `ccl_rs_group_start/end` with a single `event_wait` on the last submitted
+  op; construction supports both a from-scratch bootstrap
+  (`OneCclBootstrap` — KVS address serialized to 8B world_size + 256B KVS
+  address) and borrowed handles from PyTorch / vLLM.
+
+### Feature graph
+
+| Crate | Feature | Effect |
+|---|---|---|
+| `dynamo-memory` | `xpu-sycl` | Enables `SyclMemPool`, SYCL NUMA enumerators. Requires `oneapi-rs`. |
+| `kvbm-kernels` | `xpu-sycl` | Compiles SYCL `.cpp` sources via icpx and links `libkvbm_kernels_sycl.so`. |
+| `kvbm-kernels` | `xpu-sycl-permute` | Enables SYCL permute kernel re-exports (implies `xpu-sycl`). |
+| `kvbm-physical` | `cuda` (default) | Forwards to `dynamo-device/cuda`. Pulls in `kvbm-kernels`. |
+| `kvbm-physical` | `xpu-sycl` | Forwards to `dynamo-device/xpu-sycl`. Pulls in `kvbm-kernels/xpu-sycl`, `oneapi-rs`, and `dynamo-memory/xpu-sycl`. |
+| `kvbm-engine` | `nccl` | Compiles `collectives::nccl`. |
+| `kvbm-engine` | `oneccl` | Compiles `collectives::oneccl` + `oneccl_bootstrap`. |
+| `kvbm-py3` (bindings) | `cuda` / `xpu-sycl` | Selects which `event_sync_blocking` is emitted. Mutually exclusive. |
+| `kvbm-py3` | `nccl` / `oneccl` | Imply the corresponding device feature. |
+
+CUDA and SYCL backends can coexist in a single `kvbm-physical` build (both
+features enabled), but the bindings crate assumes exactly one of
+`cuda` / `xpu-sycl`.

--- a/deps/0016-kvbm-v2-xpu-sycl-enablement/sycl_kernels.md
+++ b/deps/0016-kvbm-v2-xpu-sycl-enablement/sycl_kernels.md
@@ -1,0 +1,229 @@
+# SYCL Kernels
+
+How the SYCL/XPU path of `kvbm-kernels` is organized: the `.cpp` sources,
+how they are compiled into `libkvbm_kernels_sycl.so` by `icpx -fsycl`, the
+`extern "C"` launcher ABI, and how the kernels dispatch work-groups.
+
+For the broader architecture and how these kernels plug into the device
+abstraction in `kvbm-physical`, see
+[`kvbm_v2_xpu_sycl_enablement.md`](../../kvbm-physical/docs/kvbm_v2_xpu_sycl_enablement.md).
+
+## File layout
+
+```
+lib/kvbm-kernels/
+├── sycl/
+│   ├── vectorized_copy_kernel.cpp   # sycl_vectorized_copy launcher
+│   └── tensor_permute_kernel.cpp    # permute launchers
+│                                    # (sycl_universal_from_block + sycl_block_from_universal)
+├── cuda/
+│   ├── tensor_kernels.cu            # CUDA kernels (unchanged)
+│   └── stubs.c                      # abort-on-call stubs when nvcc is absent
+├── src/
+│   ├── tensor_kernels.rs            # CUDA FFI (always built)
+│   ├── tensor_kernels_sycl.rs       # SYCL FFI (feature xpu-sycl)
+│   └── lib.rs
+└── build.rs                         # two-tier build (CUDA + SYCL)
+```
+
+## Build pipeline
+
+The SYCL branch in `build.rs` is driven by the `xpu-sycl` Cargo
+feature. When enabled, it compiles every
+`.cpp` under `sycl/` into a single shared library.
+
+```mermaid
+flowchart TD
+    A[cargo build] --> B{xpu-sycl feature enabled?}
+    B -- no --> DONE_CUDA[CUDA-only build<br/>links libkvbm_kernels.so]
+    B -- yes --> C{icpx on PATH?}
+    C -- yes --> D[icpx]
+    C -- no --> E{ONEAPI_ROOT set?}
+    E -- no --> PANIC[panic:<br/>icpx not found]
+    E -- yes --> F2{$ONEAPI_ROOT/compiler/latest/bin/icpx exists?}
+    F2 -- no --> PANIC2[panic:<br/>icpx not found at $ONEAPI_ROOT]
+    F2 -- yes --> F["$ONEAPI_ROOT/compiler/latest/bin/icpx"]
+    D --> G[icpx -fsycl -shared -fPIC -O2<br/>-o libkvbm_kernels_sycl.so<br/>sycl/*.cpp]
+    F --> G
+    G --> H[rustc-link-search=OUT_DIR<br/>rustc-link-lib=dylib=kvbm_kernels_sycl<br/>rustc-link-lib=sycl<br/>rustc-link-lib=stdc++]
+    H --> DONE_XPU[XPU-enabled build]
+
+    style G fill:#2196f3,stroke:#1565c0,color:#fff
+```
+
+Notes:
+
+- The CUDA branch runs regardless of `xpu-sycl` — a pure
+  XPU build still needs `cc` (or the stubs) for `libkvbm_kernels.so`.
+  This is a known rough edge; see the enablement doc for follow-up
+  items.
+- The SYCL library is a single `.so` — `icpx` takes every `.cpp` in
+  `sycl/` as one call. Adding a new kernel means adding a new `.cpp`
+  alongside the existing two; `build.rs` discovers it automatically.
+- `build.rs` emits one `cargo:rerun-if-changed=<path>` per discovered
+  `.cpp` file (Cargo doesn't expand globs in `rerun-if-changed`), so
+  `cargo build` incrementally rebuilds when any SYCL source changes.
+
+## `extern "C"` launcher ABI
+
+All three launchers use the same shape: opaque device pointer arrays,
+explicit dimension arguments, a `void*` that Rust supplies as a
+`sycl::queue*`, and an `int` return code.
+
+Naming is aligned end-to-end: the `.so` is `libkvbm_kernels_sycl.so`,
+the C++ symbols are `kvbm_kernels_sycl_launch_*`, the Rust `extern "C"`
+declarations match, and the Rust public wrappers are `sycl_*`. The
+`xpu-sycl` Cargo feature is spelled the same across `kvbm-kernels`,
+`dynamo-memory`, `dynamo-device`, `kvbm-physical`, and `kvbm-py3`, so
+every KVBM crate activates this code path with one consistent flag.
+
+```cpp
+extern "C" {
+
+int kvbm_kernels_sycl_launch_vectorized_copy(
+    void** src_ptrs, void** dst_ptrs,
+    size_t copy_size_bytes,
+    int    num_pairs,
+    void*  queue_ptr);    // sycl::queue* opaque
+
+int kvbm_kernels_sycl_launch_universal_from_block(
+    void* const*       universal_ptrs,
+    const void* const* block_ptrs,
+    size_t num_blocks, size_t nh, size_t nl, size_t no,
+    size_t nt, size_t hd, size_t elem_size,
+    int    layout_value,  // 0 = NHD, 1 = HND
+    void*  queue_ptr);
+
+int kvbm_kernels_sycl_launch_block_from_universal(
+    const void* const* universal_ptrs,
+    void* const*       block_ptrs,
+    size_t num_blocks, size_t nh, size_t nl, size_t no,
+    size_t nt, size_t hd, size_t elem_size,
+    int    layout_value,
+    void*  queue_ptr);
+
+}
+```
+
+Return values: `0` on success, `-1` on a `sycl::exception` caught
+inside the launcher. Callers in Rust wrap this with a descriptive
+`anyhow::anyhow!("... failed (rc={ret})")`.
+
+### The Rust side
+
+`src/tensor_kernels_sycl.rs` exposes one safe-ish `unsafe fn` per
+launcher; the shared `BlockLayout` enum (`NHD = 0`, `HND = 1`) is passed
+in place of the raw `int`. Tests and `kvbm-physical` call
+these functions with the queue pointer obtained via
+`oneapi_rs::safe::SyclQueue::raw_queue_ptr()`.
+
+## Kernel dispatch — `sycl_vectorized_copy`
+
+This is the hot path for FC↔LW transfers in KVBM v2. Each work-group
+handles one or more `(src, dst)` pointer pairs using a group-strided
+outer loop; inside, work-items cooperate on a single pair using
+alignment-dependent vector widths.
+
+```mermaid
+flowchart TD
+    LAUNCH["parallel_for<br/>global=min(num_pairs, 65535) × 128"] --> OUTER["for pair_id = group_id;<br/>pair_id &lt; num_pairs;<br/>pair_id += group_range"]
+    OUTER --> ALIGN{src &amp; dst<br/>alignment mask}
+
+    ALIGN -- both 16B, size ≥ 16 --> V16["uint128_t vectorized copy<br/>local-id strided over num_vec"]
+    ALIGN -- both 8B, size ≥ 8   --> V8["uint64_t vectorized copy"]
+    ALIGN -- both 4B, size ≥ 4   --> V4["uint32_t vectorized copy"]
+    ALIGN -- else                --> V1["byte-wise copy"]
+
+    V16 --> TAIL[copy remaining bytes<br/>byte-wise, local-id strided]
+    V8  --> TAIL
+    V4  --> TAIL
+    V1  --> DONE_PAIR[next pair]
+    TAIL --> DONE_PAIR
+```
+
+Constants and grid shape:
+
+- `kBlockDim = 128` — work-group size; chosen to match the CUDA
+  `blockDim.x` used by the equivalent `.cu` kernel.
+- Grid is clamped to `65535` work-groups (mirrors the CUDA grid-dim
+  cap). With `num_pairs > 65535` each group sweeps multiple pairs via
+  the strided outer loop.
+- The `uint128_t` type is declared `alignas(16)` so the compiler emits
+  a single 128-bit load/store when the pointers allow.
+
+### Why per-pair alignment probing?
+
+`batch_copy` must accept pointers that are only naturally aligned to
+the data type (2 B for fp16, 4 B for fp32, …). Hard-coding 16-byte
+vector loads would over-read past the last element. The runtime probe
+picks the widest *safe* width per pair, so wide-aligned pairs get
+full-rate SIMD and narrow-aligned pairs still correct with no
+performance cliff on short copies.
+
+## Kernel dispatch — permute kernels
+
+`universal_from_block` and `block_from_universal` are fused
+permute-and-copy kernels used by the FC↔LW path when the source and
+destination layouts disagree (NHD vs HND vs universal). The Rust side
+only calls them when the layout metadata requests permutation;
+same-layout transfers reuse `sycl_vectorized_copy`.
+
+Both kernels:
+
+- Use `kBlockDim = 256` (more in-flight work-items per group because
+  each item copies only one element).
+- Flatten the output to a 1-D index `thread_id ∈ [0, nh·nl·no·nt·hd)`
+  and decompose it back to `(block, nh, nl, no, nt, hd)` indices.
+- Compute the within-chunk byte offset via `block_inner_offset(layout,
+  …)` — a single branch on NHD vs HND.
+- Move `elem_size` bytes per work-item via `copy_element`, which
+  specializes to `uint64_t` / `uint32_t` / `uint16_t` stores for
+  `elem_size ∈ {8, 4, 2}` and falls back to a byte loop otherwise.
+- Share the same 65535-group cap as `vectorized_copy` via
+  `compute_grid_size`. With `total = num_blocks × nh × nl × no × nt × hd`
+  routinely above 65535 × 256 ≈ 16.7 M elements at production scale, the
+  inner `for (; thread_id < total; thread_id += stride)` loop strides
+  each work-item across multiple output elements. The cap is the same
+  upper bound mirrored from the CUDA kernel.
+
+Element-type dispatch is done by **byte size, not C++ templates**,
+because permute is pure data movement — no arithmetic on element
+values. This keeps the kernel a single specialization per `elem_size`
+branch rather than one per dtype.
+
+## Error surface
+
+Inside every launcher:
+
+```cpp
+try {
+    q.parallel_for( ... );
+} catch (const sycl::exception& e) {
+    fprintf(stderr, "kvbm_kernels_sycl: <launcher> failed: %s\n", e.what());
+    return -1;
+}
+```
+
+Each launcher prints the exception message (`e.what()`, which typically
+contains the underlying Level-Zero error string) to stderr before
+returning `-1`. The Rust-side FFI wrapper then converts the non-zero
+return code into a descriptive `anyhow::anyhow!("... failed (rc={ret})")`
+that propagates up through the executor.
+
+## Feature graph
+
+| Feature | Effect |
+|---|---|
+| `xpu-sycl` | Builds `src/tensor_kernels_sycl.rs` and compiles SYCL kernels via icpx. Requires DPC++ compiler. |
+| `xpu-sycl-permute` | Enables SYCL permute kernel re-exports (implies `xpu-sycl`). |
+| `testing-xpu-sycl` | Enables `tests/sycl_kernel_roundtrip.rs` integration tests; requires a real XPU device |
+| `kvbench-xpu-sycl` | Enables the `kvbench_xpu_sycl.rs` example (pulls in `clap`, `oneapi-rs`, and `xpu-sycl-permute`) |
+
+Kernel dispatch from the `dynamo-device` SYCL backend (consumed by
+`kvbm-physical`) crosses this FFI boundary through the
+`kvbm_kernels::sycl_vectorized_copy` call site in
+`lib/device/src/sycl/mod.rs`. The SYCL permute wrappers
+(`sycl_universal_from_block` / `sycl_block_from_universal`) are exported
+and covered by `tests/sycl_kernel_roundtrip.rs`, but are not currently on
+the production device-executor path. See the device executor flow doc for
+the call sequence that wraps the vectorized-copy launch.

--- a/deps/0016-kvbm-v2-xpu-sycl-enablement/sycl_pool_and_numa.md
+++ b/deps/0016-kvbm-v2-xpu-sycl-enablement/sycl_pool_and_numa.md
@@ -1,0 +1,301 @@
+# SyclMemPool and NUMA-aware pinned allocation
+
+Implementation contracts for the two pieces of `dynamo-memory` that
+matter most for the XPU/SYCL path:
+
+1. **`SyclMemPool`** — a software free-list that stands in for the
+   native pool API CUDA provides and SYCL does not.
+2. **`NumaWorkerPool`** + `PinnedAllocator` — the shared machinery that
+   routes pinned host allocation through NUMA-pinned worker threads,
+   used by both CUDA and SYCL backends.
+
+For architecture and feature-graph context see
+[`kvbm_v2_xpu_sycl_enablement.md`](../../kvbm-physical/docs/kvbm_v2_xpu_sycl_enablement.md).
+
+## `SyclMemPool` — software free-list
+
+CUDA exposes a native stream-ordered pool (`cuMemAllocFromPoolAsync` /
+`cuMemFreeAsync`). SYCL does not. `SyclMemPool` implements the same
+`alloc` / `free` semantics in software over `sycl::malloc_device` and
+`sycl::free`.
+
+### Data structure
+
+```
+PoolInner {
+    free_list:     BTreeMap<usize, Vec<FreeBlock>>,   // size → stack
+    active_allocs: HashMap<u64, usize>,               // ptr  → real_size
+    cached_bytes:  usize,                             // total cached bytes
+}
+```
+
+Every block in the pool has **one** size that is authoritative — the
+size at which `sycl::malloc_device` created it. `active_allocs` keeps
+the ptr-to-real-size mapping outside the free list so that a reused
+block does not lose its provenance.
+
+### `alloc(size)` path
+
+```mermaid
+flowchart TD
+    START["alloc(size)"] --> CHK{size == 0?}
+    CHK -- yes --> ERR[Err]
+    CHK -- no --> LOCK[lock inner]
+    LOCK --> BEST[pop_best_fit size<br/>smallest bucket ≥ size]
+    BEST --> HIT{hit?}
+    HIT -- yes --> TRACK1[active_allocs.insert ptr, block.size<br/>real size, NOT request]
+    TRACK1 --> RET1[return ptr]
+    HIT -- no --> UNLOCK[drop lock]
+    UNLOCK --> RAW[raw_alloc size<br/>sycl::malloc_device]
+    RAW --> LOCK2[re-lock inner]
+    LOCK2 --> TRACK2[active_allocs.insert ptr, size]
+    TRACK2 --> RET2[return ptr]
+
+    style TRACK1 fill:#4caf50,stroke:#2e7d32,color:#fff
+    style TRACK2 fill:#4caf50,stroke:#2e7d32,color:#fff
+```
+
+Two things to note:
+
+- On a cache hit `active_allocs` stores `block.size`, **not** the
+  caller's `size`. Best-fit can hand back a larger block; accounting
+  must follow the real block.
+- `raw_alloc` runs **outside** the mutex so concurrent misses don't
+  serialize on the SYCL driver. The second lock acquisition to record
+  the new ptr is short and race-free because nobody else can see the
+  ptr yet.
+
+### `free(ptr, size)` path
+
+The `size` parameter (here used as a hint — see note below) names the
+caller's best guess at the original allocation size.
+
+```mermaid
+flowchart TD
+    START["free ptr, size"] --> NULL{ptr == 0?}
+    NULL -- yes --> OK[return Ok]
+    NULL -- no --> LOCK[lock inner]
+    LOCK --> LOOKUP{active_allocs.remove ptr?}
+
+    LOOKUP -- Some real_size --> PUSH[push FreeBlock ptr, real_size<br/>cached_bytes += real_size]
+    LOOKUP -- None --> DA["debug_assert! untracked ptr"]
+    DA --> FALLBACK{release build?}
+    FALLBACK -- yes + hint==0 --> OK2[return Ok — no-op]
+    FALLBACK -- yes + hint>0  --> PUSH2[push FreeBlock ptr, hint]
+    FALLBACK -- debug --> PANIC[panic via debug_assert!]
+
+    PUSH --> DRAIN{cached_bytes > release_threshold?}
+    PUSH2 --> DRAIN
+    DRAIN -- yes --> PULL[drain_to threshold<br/>sycl::free the drained blocks]
+    DRAIN -- no --> DONE[return Ok]
+    PULL --> DONE
+
+    style LOOKUP fill:#4caf50,stroke:#2e7d32,color:#fff
+    style DA fill:#ffca28,stroke:#f57f17
+```
+
+The `size` argument (signature: `free(ptr: u64, size: usize)`) is
+preserved for API compatibility but acts as a hint — it is **not**
+used on the happy path. It takes effect only as a fallback when the
+caller passes a ptr the pool never issued, which in debug builds is a
+`debug_assert!` failure. The unit test
+[`test_pool_free_ignores_size_hint`](../src/pool/sycl.rs) pins this
+behavior.
+
+### Why real-size tracking matters
+
+Without it, this degradation path cripples the pool:
+
+1. Warm pool with `reserve_size = 64 MiB`. Free list: `{64 MiB → [X]}`.
+2. `alloc(1 MiB)` returns `X` (best fit). *Without tracking*, pool
+   forgets the block was 64 MiB.
+3. `free(X, 1 MiB)` pushes `{X, 1 MiB}` into the free list.
+4. Next `alloc(4 MiB)` misses the cache — there is no ≥ 4 MiB block
+   anymore — and goes to `sycl::malloc_device` for a fresh 4 MiB
+   allocation.
+
+After the first mismatched round-trip the pool stops amortizing, and
+`release_threshold` stops reflecting actual USM footprint. The
+`active_allocs` map closes that gap.
+
+### Drop semantics
+
+`Drop` uses `Mutex::get_mut()` (no lock needed because `&mut self`
+already proves exclusive access). `drain_to(0)` empties the free list
+and each block is returned via `sycl::free`. Blocks still in
+`active_allocs` are *not* freed — they are caller-owned pointers, and
+freeing them here would race a concurrent consumer.
+
+## NUMA-aware pinned allocation
+
+Both CUDA and SYCL route pinned host allocation through a single global
+`NumaWorkerPool`. A backend-specific `PinnedAllocator` runs on a
+NUMA-pinned worker thread that also performs first-touch.
+
+### The trait
+
+```rust
+pub trait PinnedAllocator: Send + Sync + 'static {
+    fn alloc_pinned(&self, size: usize) -> Result<*mut u8, String>;
+    fn free_pinned(&self, ptr: *mut u8) -> Result<(), String>;
+}
+```
+
+Two implementations live in `dynamo-device`:
+
+- `CudaPinnedAllocator` — binds the CUDA context to the pinned worker
+  thread, then calls `cuMemHostAlloc(DEVICEMAP)`.
+- `SyclPinnedAllocator` — holds an `Arc<SyclContext>` and calls
+  `context.malloc_host(size)`. SYCL USM host allocation is context-scoped,
+  so the allocator doesn't need a queue at all.
+
+### `NumaWorkerPool` topology
+
+```mermaid
+flowchart LR
+    CTX[DeviceContext.allocate_pinned size] --> PCI["pci_bdf_address()"]
+    PCI --> NODE["get_numa_node_for_pci_address<br/>(sysfs → nvidia-smi/xpu-smi fallback)"]
+    NODE --> POOL[NumaWorkerPool::global]
+    POOL --> SPAWN{worker for node exists?}
+    SPAWN -- no --> NEW[spawn thread:<br/>sched_setaffinity to node's CPUs]
+    SPAWN -- yes --> REUSE[reuse worker]
+    NEW --> SEND
+    REUSE --> SEND
+    SEND["send AllocRequest(size, node, Arc dyn PinnedAllocator)"]
+    SEND --> W1
+
+    subgraph worker[NUMA-pinned worker thread]
+        W1[verify current NUMA node]
+        W2[allocator.alloc_pinned size]
+        W3[first-touch each page<br/>write_volatile 0 to one byte per system page]
+        W4[return pointer]
+        W1 --> W2 --> W3 --> W4
+    end
+
+    W4 --> CALLER[caller receives pinned ptr]
+
+    style NEW fill:#4caf50,stroke:#2e7d32,color:#fff
+    style W3 fill:#ff9800,stroke:#ef6c00,color:#fff
+```
+
+Key invariants:
+
+- One worker per NUMA node, spawned lazily and kept alive for the
+  process lifetime.
+- The worker pins itself **before** servicing any request, then yields
+  briefly so the kernel scheduler can actually migrate the thread to
+  the target node (pinning is synchronous but migration is cooperative).
+- `do_pinned_allocation` checks `get_current_cpu_numa_node()` before
+  the allocation and again before first-touch; mismatches log a
+  `tracing::error!` so badly-placed pages are observable in production.
+- First-touch touches one byte per system page (`sysconf(_SC_PAGESIZE)`,
+  fallback 4 KiB) plus the final byte when the allocation is not
+  page-aligned. Touching forces Linux to bind the page to the
+  worker's current NUMA node under the default *first-touch* policy.
+
+### Timeout and cleanup
+
+Per-request timeout is `max(10, 10 + size_gib)` seconds clamped to 300 s.
+If the caller drops the response channel before the worker sends (e.g.,
+the caller errored out), the worker detects the drop and calls
+`allocator.free_pinned(ptr)` rather than leaking the allocation.
+
+The worker thread exits when its request channel is dropped — normally
+at process shutdown, since the pool is a `OnceLock` global.
+
+## Cross-backend consistency
+
+| Aspect | CUDA path | SYCL path |
+|---|---|---|
+| Allocator trait | `CudaPinnedAllocator: PinnedAllocator` | `SyclPinnedAllocator: PinnedAllocator` |
+| Backend-specific thread binding before alloc | yes — `ctx.bind_to_thread()` so the cudarc context follows the worker thread | no — SYCL USM host allocation is context-scoped |
+| First-touch done in worker? | yes (shared logic in `NumaWorkerPool`) | yes (same code) |
+| PCI BDF source | `CU_DEVICE_ATTRIBUTE_PCI_{DOMAIN,BUS,DEVICE}_ID` | `SyclDevice::info().pci_address` |
+| NUMA node lookup | `/sys/bus/pci/devices/<bdf>/numa_node`, fallback `nvidia-smi topo` | same sysfs lookup, fallback `xpu-smi discovery` parsing |
+
+The "backend-specific thread binding" row is **not** about NUMA pinning
+— the NUMA worker thread itself is always pinned via
+`sched_setaffinity` regardless of backend. The row only refers to
+backend-runtime context binding (CUDA's per-thread current-context
+state); SYCL has no equivalent because allocations go through
+`SyclContext` directly.
+
+First-touch semantics are identical because the first-touch walk runs
+in `NumaWorkerPool` regardless of backend. The only backend-specific
+logic is *how* the underlying allocation is made.
+
+## Validating first-touch on real hardware
+
+`lib/kvbm-physical/bin/validate_numa_placement.rs` is a diagnostic
+binary that exercises the full NUMA allocation path on either backend
+and verifies with `move_pages(2)` that every page landed on the
+expected NUMA node. It's the authoritative answer to "does first-touch
+actually work on my system?".
+
+The backend is resolved in two steps: **compile time** (which Cargo
+features were enabled) and **runtime** (what `--backend` picks). Only
+a backend that was compiled in can be selected at runtime — otherwise
+the binary prints an actionable rebuild hint and exits.
+
+```bash
+# CUDA host (default features include `cuda`) — auto-detect picks CUDA:
+cargo run -p kvbm-physical --bin validate_numa_placement
+
+# CUDA host, larger allocation, subset of devices:
+cargo run -p kvbm-physical --bin validate_numa_placement -- \
+    --size 64 --gpus 0,2
+
+# Intel XPU host — requires the `xpu-sycl` feature (which enables
+# `xpu-sycl` in `kvbm-kernels`, triggering `icpx -fsycl`):
+    cargo run -p kvbm-physical \
+        --no-default-features --features xpu-sycl \
+        --bin validate_numa_placement -- \
+        --backend sycl --size 64 --gpus 0,2
+
+# Mixed host with both backends compiled in:
+    cargo run -p kvbm-physical --features cuda,xpu-sycl \
+        --bin validate_numa_placement -- --backend sycl
+```
+
+The binary builds under either `cuda` or `xpu-sycl` (or both
+simultaneously); at runtime it reports which backends were compiled in
+and refuses to use any that weren't. For each device it:
+
+1. Resolves the PCI BDF through `DeviceContext::pci_bdf_address()`
+   (same path `allocate_pinned` uses internally).
+2. Looks up the expected NUMA node via
+   `dynamo_memory::numa::get_numa_node_for_pci_address`.
+3. Allocates pinned memory via `PinnedStorage::new(size, ctx)` — this
+   drives `NumaWorkerPool` → `PinnedAllocator` → first-touch exactly
+   as production code does.
+4. Calls `move_pages(2)` with `nodes = NULL` to read back each page's
+   real NUMA node.
+5. Reports per-device pass/fail and exits non-zero if any device is
+   misplaced.
+
+Run this on a multi-NUMA Intel host before trusting SYCL pinned
+allocation — it's the only end-to-end proof that SYCL
+`sycl::malloc_host` defers page population long enough for the
+worker's first-touch walk to bind pages correctly.
+
+## Gotcha: `SyclMemPool.free(ptr, 0)`
+
+The previous implementation returned `Ok(())` early on `size == 0`.
+After the real-size fix, `free(0, _)` is the only short-circuit —
+`free(nonzero_ptr, 0)` now looks up the real size from `active_allocs`
+and frees correctly. Callers that used to pass `size = 0` as a
+"no-op" trigger will now perform the real free. This is intentional:
+the `size` argument was never meant to control whether the free
+happens.
+
+Tests in `pool/sycl.rs::tests` pin both behaviors:
+
+- `test_pool_free_null_ptr_noop` — `free(0, _)` is a no-op.
+- `test_pool_free_ignores_size_hint` — `free(tracked_ptr, 0)` still
+  recycles the tracked ptr at its real size, and a subsequent alloc
+  hits the cache.
+
+## Related reading
+
+- Device-side usage of the pool: [`device_executor_flow.md`](../../kvbm-physical/docs/device_executor_flow.md), step 2 and step 6 of `execute_fc_lw_vectorized`.
+- How the SYCL backend wires these pieces into `DeviceContextOps`: [`kvbm_v2_xpu_sycl_enablement.md`](../../kvbm-physical/docs/kvbm_v2_xpu_sycl_enablement.md).


### PR DESCRIPTION
Please align with DEP https://github.com/ai-dynamo/dynamo/issues/9313.
Describe the design and implementation details about how Intel XPU (SYCL/oneAPI) was integrated into KVBM v2 alongside the existing NVIDIA CUDA backend: the trait surfaces that were extracted, the SYCL implementations that were added, and the crate-level wiring that keeps KVBM v2 engine-agnostic and framework-agnostic. The documents covers the state of the branch, the evolution from the CUDA-only baseline, and the relationships between the crates under lib/ that make up KVBM v2. 

**Implementation PR:**  
https://github.com/ai-dynamo/dynamo/pull/7946

**Question:**
Need to know what will be changed and what will be not changed for KVBM v2.  e.g.,  kvbm-common/kvbm-config/kvbm-engine/kvbm-kernels/kvbm-logical/kvbm-physical/memory/bindings,etc.

- What crates will serve KVBM v2?  
- What are the new crates for KVBM v2? Please share the schedule of merging new crates into main, e.g. kvbm-connector.
- Will the basic operations (e.g., in device_executor_flow.md, collectives.md, sycl_kernels.md, etc.) be changed? 
- Will KVBM v2 decouple with llm/block_manager ?

**Concern:**
Measure xpu perf ( [kvbm_v2_xpu_sycl_enablement.md](https://github.com/zxue2/dynamo/blob/enable_kvbm_v2_xpu_dev/lib/kvbm-physical/docs/kvbm_v2_xpu_sycl_enablement.md#benchmarks)) from different API layers based on raw API(kvbench in kvbm-kernel with Intel SYCL rust binding),  bench transfer (bench_transfer with transfer manager API in kvbm-physical)  and bench_engine ( in kvbm-engine)  with unified abstracted processes for batch copy, vectorized copy(GPU kernel), OneCCL(broadcast for MLA), NUMA pinned memory allocation, etc. 