### PR TITLE
DEP: Rust EPP Plugins

### DIFF
--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -44,7 +44,7 @@ rebuilt privately by every implementation. Everything else — parsing, the KV-a
 scheduler/picker, and bookkeeping — stays built in. We deliberately do not reproduce
 the full llm-d pipeline.
 
-The worker-state view is the load-bearing addition. A shedding policy that cannot
+The worker-state view is a critical addition. A shedding policy that cannot
 see KV-cache and prefill saturation is not a shedding policy, and today no extension
 point can see it: `EndpointPicker::pick` receives request metadata and an endpoint
 list carrying pod identity only, so any out-of-tree policy must stand up a parallel
@@ -68,26 +68,19 @@ policy must fork it. Three concrete needs drive this proposal:
   serving must look at KV-cache and queue saturation, not generic request rate.
   It belongs inside the EPP and users want to supply their own policy. Dynamo's
   frontend already sheds load (HTTP 529); the GAIE path needs the same, made
-  extensible. The *built-in* half of this is in flight in
+  extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers pressing on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity.
+  The *built-in* half of this is in flight in
   [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which
   reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated
-  { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. That
-  makes shedding an explicit, gateway-routable routing signal rather than an
-  implicit shed-by-timeout — but the thresholds are process-wide environment
-  variables and the predicate is fixed. What remains is the seam that lets a
-  deployment supply its own predicate.
-- **Policy state must be shared, not rebuilt.** Every interesting overload or
-  prioritization policy consumes the same family of signals: active decode blocks
-  and KV used blocks against `kv_total_blocks`, and active prefill tokens against
+  { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry
+  over: `POST`/`GET /busy_threshold` retunes thresholds per model on a live fleet,
+  whereas the EPP reads env vars once at startup. Closing that is out of scope here but needs to be done.
+- **Policy state must be shared.** Every prioritization policy consumes the same family of signals: active decode blocks and KV used blocks against `kv_total_blocks`, and active prefill tokens against
   `max_num_batched_tokens`. The EPP already tracks these in `WorkerLoadState`. They
   are not reachable from any extension point, so each out-of-tree policy would have
-  to re-derive them from its own subscription — duplicate plumbing, and a second
+  to re-derive them from its own subscription. We want to avoid duplicate plumbing, and a second
   source of truth that can silently disagree with the one the built-in shedder uses.
-  The disagreement is not hypothetical: decode overload is *latched*, clearing only
-  once both the active-blocks and kv-used-blocks signals fall back under threshold,
-  so a reimplementation fed identical raw metrics but lacking the latch will flap
-  where the built-in shedder holds steady. This is the single most requested item
-  from integrators (REQ 1) and the main change in this revision.
+  This leads to (REQ 1).
 
 ## Goals
 
@@ -98,10 +91,12 @@ policy must fork it. Three concrete needs drive this proposal:
   of truth.
 * Move today's inline tokenization behind the default PrepareData plugin with no
   behavior change.
-* Ship a default load-shedding plugin with parity to the frontend's
-  saturation / busy-threshold behavior.
-* Keep the architecture simple; an unconfigured Rust EPP behaves as it does
-  today.
+* Ship a default load-shedding plugin that reuses the frontend's saturation /
+  busy-threshold *detection* — the same `KvWorkerMonitor`, thresholds, and
+  overloaded-worker exclusion — while deliberately diverging on the decision surface:
+  an explicit pre-tokenization gate rather than a routing failure surfaced as an
+  error, and HTTP 429 with `Retry-After` rather than 529. Full parity is not the
+  goal; a shared detector with a gateway-appropriate contract is.
 * Allow users to add plugins via compile-time registration in a custom Rust EPP
   binary/image.
 
@@ -114,8 +109,9 @@ policy must fork it. Three concrete needs drive this proposal:
   request, but it does not participate in scoring or selection.
 * Steering the router's internal scoring from an EPP extension — for example
   zeroing a worker's prefix-overlap credit, retuning the KV indexer's TTL decay, or
-  forcing an index resync for one worker. These are legitimate needs (see REQ 4)
-  but they are operations on the router's own state, not on the EPP's request path,
+  forcing an index resync for one worker. Integrators have asked for these, and they
+  are legitimate needs, but they are operations on the router's own state, not on the
+  EPP's request path,
   and giving the EPP a back door into them would create exactly the coupling the
   first non-goal avoids. They belong to the router and its policy-class admission
   API.
@@ -153,38 +149,38 @@ gateway, with a retry hint. **Met by
 { retry_after_secs }` → HTTP 429 with `Retry-After`. Because it is an ordinary error
 variant, an out-of-tree policy can return it too.
 
-### REQ 3 Response usage on the completion callback
 
-The terminal response's token usage — at minimum
-`usage.prompt_tokens_details.cached_tokens` — must reach the picker so a deployment
-can compare predicted prefix overlap against the observed cache hit. **Met by
-[dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868)** ("Enable
-cached_tokens in EPP response", DYNO-93), which adds
-`on_request_complete_with_usage`. Note this is a
-per-request feedback input, not telemetry: the `dynamo_epp_cached_tokens` histogram
-added alongside it is labelled by model only and cannot be joined to an individual
-pick decision.
+### REQ 3 Class-aware shed thresholds
 
-### REQ 4 Closed-loop calibration of the predictor
+Today the threshold is one number for everybody. For example, shed when a worker is over 85% KV-block occupancy. The #11865 rejects only when every eligible worker is over it. So the pool has exactly two states: open to all, or closed to all. The moment saturation is crossed, a 200-token chat request and a 100k-token request get treated identically: both get a 429. The customers want flexibility here as not all requests are equal under load. The EPP already knows prompt size because it tokenized, and a retry marker is one header away so we can extend this.
+The router side already has most of the machinery: the KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket — that is, bucketed on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length. So request-size-aware classes exist; what's missing is expressing shed thresholds per class rather than process-wide.
 
-Sustained disagreement between predicted overlap and reported `cached_tokens` should
-be able to act on the predictor: retune decay parameters where routing is
-approximate, and demote or resync a diverged worker where it is event-driven.
-**Out of scope for this DEP**, and worth being explicit about why. The actions are
-operations on router state, unreachable from `EndpointPicker` — an extension can
-wrap the picker but cannot change how the picker scores. Recording the error ledger
-is already possible with REQ 3; acting on it is router work. Note also that the EPP
-has no approximate-routing mode today, so the parameter-adaptation half of this
-requirement has no surface to act on.
+The classifier itself is reusable — `PolicyProfile::resolve_class_index` is public, not
+scheduler-internal. The complication is its argument: it takes *uncached* tokens, and
+the EPP cannot know those at shed time. Overlap comes from the KV index query inside
+`pick()`, whereas the shed gate runs before the body is even decoded. So this
+requirement resolves into one of three options, which differ in cost and in whether the
+router changes at all:
 
-### REQ 5 Class-aware shed thresholds
+1. **Classify on raw token count in the EPP.** No router change. The EPP keeps its own
+   per-class threshold table and buckets on prompt length. Cheapest, but the EPP's
+   class for a request then disagrees with the router's, so one request can be a
+   "small" shed class and a "large" queue class at the same time — the two-sources-of-
+   truth problem this DEP objects to elsewhere, in a new place.
+2. **Move the shed gate after tokenization and the overlap query.** No router change,
+   and class identity stays consistent, but it gives up the cheap pre-parse refusal
+   that distinguishes the EPP's shed from the frontend's error-driven one.
+3. **Push the decision into the router**, where uncached tokens and class assignment
+   already sit together. This is the only option requiring a router contract change:
+   `AdmissionDecision` is `Bypass | Ready | Defer` today, with no rejection variant, so
+   the policy-class admission API can hold a request indefinitely but cannot shed one.
 
-A uniform threshold turns "nearly full" into "closed for everyone at once," which is
-when retry amplification starts. Shedding should be able to distinguish request
-classes — keeping small first attempts flowing while shedding oversized retries,
-which are the cheapest to redirect. **Not met in the EPP.** The EPP already knows
-prompt size because it tokenized, and a retry marker is one header away. The router
-side already has most of the machinery; see the division of labor below.
+A related question is where per-class thresholds are configured. They arguably belong
+beside the class definitions in the router's policy YAML — which already carries a
+per-class `admission:` envelope — rather than in EPP environment variables, since
+splitting class definitions from class thresholds invites drift.
+
+This DEP does not pick one yet; the choice should be made before implementation starts.
 
 # Proposal
 
@@ -311,7 +307,7 @@ you cheaply refuse work you should never start, and the scheduler is where you h
 work that is worth waiting for. Building a third mechanism to span them would be a
 mistake.
 
-This division also gives REQ 5 its natural home. Policy classes are already assigned
+This division also gives REQ 3 its natural home. Policy classes are already assigned
 either by explicit class name or by a `(policy family, uncached-ISL bucket)` pair —
 that is, **request-size-aware classes already exist** in the router, which is most of
 what class-aware shedding asks for. The remaining work is connective rather than new
@@ -353,7 +349,7 @@ loading in this first cut.
 4. Add the config plumbing to select / chain plugins, with the built-in shedder as
    the default load-shedding plugin.
 5. Express shed thresholds per policy class rather than process-wide, reusing the
-   router's existing class assignment. Satisfies REQ 5.
+   router's existing class assignment. Satisfies REQ 3.
 6. Document the authoring model and ship one example custom plugin alongside the
    existing GAIE docs.
 
@@ -368,7 +364,7 @@ frozen around the wrong shape.
   fleet-level loop. One worker-state surface should feed both the Relay and the
   EPP's policies rather than two parallel paths.
 * [Priority scheduling proposal](https://github.com/ai-dynamo/enhancements/pull/90) —
-  decides whether EPP-side prioritization aligns with GAIE; REQ 5 depends on the
+  decides whether EPP-side prioritization aligns with GAIE; REQ 3 depends on the
   outcome.
 * [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865) — "Enable load
   shedding in the EPP" (DEP-1073). Adds the built-in shedder this DEP's default plugin
@@ -377,9 +373,11 @@ frozen around the wrong shape.
   `WorkerLoadState` is exactly what REQ 1 proposes to expose.
 * [dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868) — "Enable
   cached_tokens in EPP response" (DYNO-93). Parses `usage` from the response body and
-  adds `on_request_complete_with_usage`, giving a policy the observed cache hit to
-  compare against its predicted overlap. Satisfies REQ 3 and is the precondition for
-  the error ledger described in REQ 4.
+  adds `on_request_complete_with_usage`. Not a plugin concern — it extends a built-in
+  `EndpointPicker` callback, and neither plugin point in this proposal runs on the
+  response path — but it is adjacent in-flight work in the same crate, and it supplies
+  the observed cache hit that integrators want for comparing predicted overlap against
+  actual, which this DEP treats as router work rather than an extension point.
 
 The two are complements, not overlaps: #11865 reads worker capacity on the request
 path to decide whether to admit, and #11868 reads request outcome on the response

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -37,7 +37,9 @@ previously only existed in Go.
 This proposal adds a minimal extension model to the Rust EPP: **two plugin types and
 one shared input**. The plugins are **DataProducer** (per-request data preparation before
 scheduling; tokenization is the first use) and **Admitter (load shedding)** (reject
-a request under overload before scheduling). 
+a request under overload). The Admitter runs after the scheduler has picked a worker and
+before the request is booked; "Why the Admitter runs after the scheduler" below explains
+why it sits there rather than in front of the scheduler as llm-d does.
 
 All plugins will need to have read-only worker-state view (the KV and prefill load signal)
 The worker-state view is a critical addition. A shedding policy that cannot
@@ -109,7 +111,7 @@ pub struct WorkerLoadState {
 * Ship a default load-shedding plugin that reuses the frontend's saturation /
   busy-threshold detection (the same `KvWorkerMonitor`, thresholds, and
   overloaded-worker exclusion) while deliberately diverging on the decision surface:
-  an explicit pre-tokenization gate rather than a routing failure surfaced as an
+  an explicit admission gate rather than a routing failure surfaced as an
   error, and HTTP 429 with `Retry-After` rather than 529. Full parity is not the
   goal; a shared detector with a gateway-appropriate contract is.
 * Allow users to add plugins via compile-time registration in a custom Rust EPP
@@ -164,8 +166,8 @@ We will take the uncached_tokens argument as the proxy for the request size. Thi
 Today the shed decision is funtion_of(worker_state). The client wants function_of(worker_state, request_class).
 
 
-The router side already has some of the machinery in the KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket — that is, bucketed on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length.
-But it drives queueing, and the shed path never calls it. They're also in different crates: classification in dynamo-kv-router, shed threshold in dynamo-llm's monitor. We need to use the classifier from it. 
+The router side already has some of the machinery. The KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket, bucketing on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length.
+But it drives queueing, and the shed path never calls it. They're also in different crates: classification in dynamo-kv-router, shed threshold in dynamo-llm's monitor. We need to use the classifier from the kv router. 
 The classifier itself is implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, and the EPP cannot know those at shed time. Overlap comes from the KV index query inside `pick()`, whereas the shed gate runs before the body is even decoded. 
 
 ```bash
@@ -181,7 +183,7 @@ pub fn resolve_class_index(&self, requested: Option<&str>, uncached_tokens: usiz
 ```
 We can run this alg before we select the worker and feed the tokens from the prompt into uncached_tokens BUT this would result in making the shedding worse. Raw ISL would systematically over-estimate cost on that traffic, so a mostly-cached large request would land in the "oversized" bucket and get shed — the precise issue we want to prevent.
 
-This complication forces use to move the class - aware shedding after the workers are picked. This incurs additional overhead for a request we can potentially drop but this preserves our routing semantics. 
+This complication forces use to move the class-aware shedding logic after the workers are picked. This incurs additional overhead for a request we can potentially drop but this preserves our routing semantics. 
 The route_decode() function returns the returns overlap_blocks we need for the `resolve_class_index`. The signature is `Result<(WorkerWithDpRank, overlap_blocks)>`. We can then run
 ```bash
 let (decode_worker, overlap_blocks) = self.route_decode(/* ... */).await?;
@@ -191,19 +193,33 @@ let cached_tokens =
 let uncached_tokens = tokens.len().saturating_sub(cached_tokens);
 ```
 
-The following flow is proposed:
-Router::pick()                          epp.rs   — general method in EPP
- ├─ GATE A                              epp.rs   — This is basic shedding implemented in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865). This is not a plugin 
- ├─ tokenize
- ├─ Router::route_prefill()             epp.rs   — thin wrapper, no change
- │    └─ PrefillRouter::…                        — kv-router, no change
- ├─ Router::route_decode()              epp.rs   — thin wrapper, no change
- │    └─ KvRouter::find_best_match()             — kv-router, no change
- │         returns (worker, overlap_blocks)
- ├─ GATE B                              epp.rs   — This will be a plugin for the new Class-Aware shedding  per customer request
- ├─ resolve the worker endpoint
- └─ Router::add_request()               epp.rs   — existing router book keeping
-      └─ KvRouter::add_request()                 — kv-router, no change
+The following flow is proposed. `Router::pick()` is the `EndpointPicker` trait method in
+`epp.rs`; everything below it runs inside that call.
+
+```text
+Router::pick()                             epp.rs
+ ├─ GATE A                                 epp.rs      (1)
+ ├─ tokenize                               epp.rs
+ ├─ Router::route_prefill()                epp.rs       thin wrapper
+ │    └─ PrefillRouter::…                  kv-router    unchanged
+ ├─ Router::route_decode()                 epp.rs       thin wrapper
+ │    └─ KvRouter::find_best_match()       kv-router    unchanged
+ │         → (worker, overlap_blocks)
+ ├─ GATE B                                 epp.rs      (2)  ← new
+ ├─ resolve the worker endpoint            epp.rs
+ └─ Router::add_request()                  epp.rs       bookkeeping
+      └─ KvRouter::add_request()           kv-router    unchanged
+```
+
+1. **GATE A** — basic, request-blind shedding, already implemented in
+   [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865). Not a plugin. It runs
+   before tokenization, so it costs nothing to refuse a fully saturated pool.
+2. **GATE B** — the new class-aware shedding, exposed as a plugin. It sits after
+   selection so it can derive uncached ISL from `overlap_blocks`, and before
+   `add_request`, so nothing is booked yet and a rejection needs no rollback.
+
+Everything marked `unchanged` is `dynamo-kv-router` code this proposal does not touch:
+scoring, selection, and the router's own bookkeeping all stay as they are.
 
 
 The per-class thresholds should be configured in the router's policy YAML — which already carries a
@@ -217,25 +233,28 @@ This DEP does not pick one yet; the choice should be made before implementation 
 ## Overview
 
 Keep the existing request flow and insert two plugin points around the existing
-scheduler, both reading one shared worker-state view:
+scheduler — data preparation in front of it, admission behind it — both reading one
+shared worker-state view:
 
-```
-                                        worker-state view (read-only, shared)
-                                             |            |
-ext_proc request                             v            v
-  -> parse body / build request          (built in)
-  -> DataProducer plugin                 (pluggable)  <-- tokenization lives here
-  -> Admitter (Load-shedding) plugin     (pluggable)  <-- reject under overload
-  -> Scheduler: pick worker              (built in, existing KV router)
-  -> attach routing headers / tokens     (built in)
-  -> return decision to Envoy
-  -> response callbacks                  (built in)  <-- prefill complete, usage
+```text
+ext_proc request
+  → parse body / build request            built in
+  → GATE A: global saturation shed        built in    request-blind, dynamo#11865
+  → DataProducer plugin                   pluggable   tokenization lives here    [view]
+  → Scheduler: pick worker                built in    existing KV router, unchanged
+  → GATE B: Admitter (load shedding)      pluggable   reject under overload      [view]
+  → book the request + attach headers     built in
+  → return decision to Envoy
+  → response callbacks                    built in    prefill complete, usage
+
+[view] = reads the shared read-only worker-state view
 ```
 
-This mirrors the useful part of the llm-d / GAIE flow (PrepareData, then
-admission, then scheduling) without the surrounding machinery.
+This takes the useful part of the llm-d / GAIE flow — a data-preparation stage and a
+separate stage that may reject — without the surrounding machinery. For reference,
+llm-d's own ordering is:
 
-```
+```text
 Parse body → Build LLMRequest → Flow control   ← builtin, not pluggable
     → DataProducer plugins   ← tokenization runs here
     → Admitter plugins       ← can reject
@@ -258,9 +277,29 @@ llm-d admits in two distinct places:
 * **`Admitter` plugins** run after `DataProducer` and before scheduling, and these
   *can* reject outright. The `latency-slo-admitter`plugin is an example here.
 
-The load-shedding plugin proposed here is the `Admitter`: same pipeline position,
-same ordering relative to data preparation, same ability to reject. That
-correspondence is the reason the seam sits where it does.
+The load-shedding plugin proposed here is that `Admitter`: same ability to reject
+outright, same read-only view of saturation, same ordering relative to data
+preparation. It diverges upstream in one respect — it runs *after* the scheduler rather
+than in front of it.
+
+### Why the Admitter runs after the scheduler
+
+Dynamo's cost proxy for a request is uncached ISL: the prompt tokens that actually need
+prefilling. That number is derived from `overlap_blocks`, which does not exist until
+`KvRouter::find_best_match()` has consulted the prefix index. Admitting in front of the
+scheduler would see raw prompt length only, and raw length mis-prices exactly the
+requests a class-aware policy cares about — a 100k-token prompt that is 95% cached is
+cheap, while an 8k-token prompt that is entirely uncached is not. Getting overlap earlier
+would mean either a second prefix-index query or reordering the router, and leaving
+`dynamo-kv-router` untouched is a constraint of this proposal. The gate therefore sits
+after selection and before `Router::add_request()`, where nothing has been booked yet, so
+a rejection needs no rollback.
+
+Deciding late costs something: a rejected request has already paid tokenization and the
+index query. Gate A bounds that cost. When every eligible worker is saturated the
+built-in shed refuses before any of that work happens, so the late gate only pays on
+requests that had a plausible home. llm-d can admit earlier because its
+`latency-slo-admitter` does not consult prefix overlap.
 
 
 The upstream split between the saturation *signal* and the admit/reject *decision*
@@ -273,16 +312,17 @@ does both. This is TBD.
 |-------|----------------|-----------|
 | `ext_proc` protocol / server | No | Transport; not a policy decision |
 | Parse body / build request | No | Stable, shared parsing |
+| Global saturation shed (Gate A) | No | Process self-protection; fixed threshold, already built in |
 | DataProducer (tokenization) | Yes | Users need different tokenizers; enables prefix-cache routing and tokens-in forwarding |
-| Admitter (Load shedding) | Yes | Users need their own overload policy |
-| Worker-state view | No — read-only input | Not a stage. One shared source of truth for the signals policies need (REQ 1) |
 | Scheduler (worker pick) | No (for now) | The existing KV-aware router stays the default; can be revisited later |
+| Admitter (load shedding, Gate B) | Yes | Users need their own overload policy |
+| Worker-state view | No — read-only input | Not a stage. One shared source of truth for the signals policies need (REQ 1) |
 | Bookkeeping / headers | No | Internal correctness |
 
 The Rust EPP is currently `ext_proc` + scheduler; this proposal adds exactly two
-pluggable stages in front of the scheduler, one read-only input feeding them, and
-leaves the scheduler built in. We are not making parsing, scoring, or picking
-pluggable at this time.
+pluggable stages around the scheduler — data preparation in front of it, admission
+behind it — plus one read-only input feeding both, and leaves the scheduler itself built
+in. We are not making parsing, scoring, or picking pluggable at this time.
 
 ## How the plugins work (conceptually)
 
@@ -292,12 +332,13 @@ pluggable at this time.
   default PrepareData plugin. If token data is already present (e.g. a pre-tokenized
   request), the plugin is skipped. PrepareData is fail-open: if a plugin errors, the
   request still proceeds and scheduling falls back to prompt-based behavior.
-* **Admitter (Load-shedding)** plugins run next and default to allow: each plugin may reject
+* The scheduler then runs unchanged, consuming the token data that DataProducer produced
+  and yielding a selected worker together with its `overlap_blocks`.
+* **Admitter (Load-shedding)** plugins run last and default to allow: each plugin may reject
   (mapped to HTTP 429 / 503, with 529 available for Dynamo clients); if none
   reject, the request proceeds. Multiple plugins can be chained and any rejection
-  stops the request.
-* The scheduler then runs unchanged, consuming the token data that PrepareData
-  produced.
+  stops the request. Because the gate precedes `Router::add_request()`, a rejection
+  leaves no booking to undo.
 * We should also reconsider how to do priority scheduling to decide if we want to align with GAIE. See related [proposal](https://github.com/ai-dynamo/enhancements/pull/90)
 
 ## Worker state as a first-class input
@@ -467,11 +508,11 @@ lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 * Over-engineered for current needs. The two plugins plus the shared state view cover
   the real use cases (custom tokenizer, custom overload policy). Additional
   extension points can be proposed later if a concrete need appears.
-* The gap is also narrower than it looks. `DataProducer` and `Admitter` are the only
-  two plugin points llm-d places between request parsing and scheduling, so this
-  proposal already matches upstream over that span. What Alt 1 adds beyond it is the
-  flow-control machinery and pluggable scoring — both already Non Goals, and the
-  former not pluggable upstream either.
+* The gap is also narrower than it looks. `DataProducer` and `Admitter` are the only two
+  plugin points llm-d exposes anywhere around scheduling, and this proposal adopts both —
+  differing only in where the `Admitter` sits relative to the scheduler, for the reason
+  given above. What Alt 1 adds beyond that is the flow-control machinery and pluggable
+  scoring — both already Non Goals, and the former not pluggable upstream either.
 
 ## Alt 2 Keep load shedding / tokenization out of the EPP (gateway-level only)
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -131,15 +131,9 @@ is about retry-versus-first-attempt and request size, not tenant tiers.
 
 ### REQ 1 Worker state as a first-class input
 
-Worker state feeds (as the integrator framed it: KV blocks, prefill tokens, queue
-depth) must be an input to the extension boundary rather than something each policy
-derives itself. Note that of these, KV blocks and prefill tokens are tracked today;
-queue depth is not, and this DEP proposes exposing what exists rather than adding a
+Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to the extension boundary rather than something each policy derives itself. Note that of these, KV blocks and prefill tokens are tracked today; queue depth is not, and this DEP proposes exposing what exists rather than adding a
 new signal. **Not yet met.**
-`pick()` receives request metadata and an endpoint list of pod identity only; in
-practice the server passes an empty endpoint slice because pickers resolve endpoints
-internally. All load signal is private to the concrete router. This is the gap this
-revision closes.
+
 
 ### REQ 2 Shed semantics distinguishable from failure
 
@@ -253,6 +247,15 @@ overload signal in `KvWorkerMonitor` and keeps it private to the concrete router
 a plugin would either be handed a pre-baked boolean or have to build its own feed. The
 first is not a policy seam; the second duplicates plumbing and creates a second
 source of truth that can disagree with the built-in shedder.
+
+None of this is new data. `KvWorkerMonitor` already holds
+`worker_load_states: Arc<DashMap<u64, WorkerLoadState>>`, kept current by its own
+background task against the Dynamo runtime and already recomputing the derived
+overloaded set on every update. There is nothing to fetch: the gap is that this `Arc`
+is a private field and the trait boundary has no parameter to pass it through. The
+cheap fix is for the monitor to publish an immutable snapshot into a `watch` channel —
+a pattern it already uses internally — so the update path pays the cost and each
+decision takes one refcount bump rather than a map traversal.
 
 Instead, the same state the built-in shedder consumes is exposed once, read-only, at
 the extension boundary:

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -326,9 +326,7 @@ Three properties hold that line:
 
 Dynamo already has a second extension boundary that is easy to miss and must not be
 duplicated: `PolicyClassAdmissionPolicy`, in
-`lib/kv-router/src/scheduling/queue_admission/`. It is contract-complete — per-class
-lifecycle events, an opaque per-class configuration envelope each policy
-deserializes itself, and crucially a `Defer` / `MakeReady` pair, so it can *hold* a
+`lib/kv-router/src/scheduling/queue_admission/`. The router can *hold* a
 request rather than only rejecting it. It has no production implementations today
 and is not wired into the EPP.
 
@@ -346,16 +344,6 @@ you cheaply refuse work you should never start, and the scheduler is where you h
 work that is worth waiting for. Building a third mechanism to span them would be a
 mistake.
 
-This division also gives REQ 3 its natural home. Policy classes are already assigned
-either by explicit class name or by a `(policy family, uncached-ISL bucket)` pair —
-that is, **request-size-aware classes already exist** in the router, which is most of
-what class-aware shedding asks for. The remaining work is connective rather than new
-machinery: the EPP knows prompt size and can see a retry marker, so it can label a
-request with a policy class, and shed thresholds can then be expressed per class
-instead of process-wide. Whether that label rides the existing `policy_class` hint
-(the frontend takes a `policy-class` metadata key; the selection service takes an
-`x-dynamo-meta-policy-class` header) or a dedicated EPP-side mapping is an
-implementation question this DEP defers.
 
 ## Configuration
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -210,7 +210,7 @@ advisory query, reads `cached_tokens` and `selected_worker_load`, then calls
 same decision shape, so this is an existing mechanism rather than a new one.
 
 **Performing the advisory query is the plugin's responsibility, not the pipeline's.** The
-Admitter therefore stays where llm-d puts it — after data preparation, before the
+Admitter therefore stays similar to where llm-d puts it — after data preparation, before the
 scheduler — and a policy that needs overlap-derived facts issues the advisory query
 itself. That makes the cost opt-in. A deployment running no Admitter, or one whose policy
 keys only on worker state and request headers, routes exactly once and pays nothing extra.

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -64,13 +64,7 @@ policy must fork it. Three concrete needs drive this proposal:
   and future tokens-in forwarding to model servers.
 - **Load shedding must be pluggable and LLM-aware.** Overload protection for LLM
   serving must look at KV-cache and queue saturation, not generic request rate.
-  It belongs inside the EPP and users want to supply their own policy. Dynamo's
-  frontend already sheds load (HTTP 529); the GAIE path needs the same, made
-  extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers pressing on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity.
-  The beginning of its implementation is in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated
-  { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry
-  over: `POST`/`GET /busy_threshold` returns thresholds per model on a live fleet,
-  whereas the EPP reads env vars once at startup. Closing that is out of scope here but needs to be done.
+  Users want to supply their own policy. The shedding must happen at the EPP level. 
 - **Policy state** must be shared, not rebuilt. Any policy reasoning about saturation needs the signals the built-in thresholds are already expressed in: active_decode_blocks and kv_used_blocks against kv_total_blocks, and active_prefill_tokens against max_num_batched_tokens. These span two feeds — numerators from the ActiveLoad stream, denominators from the runtime-config watch — and WorkerLoadState already joins them. It lives in dynamo-llm, which the EPP links today, so the EPP should construct a KvWorkerMonitor and reuse it rather than grow a parallel implementation. Tracking is only half the gap: the state is a private field and EndpointPicker::pick has no parameter. We need to expose it to enable plugins:
 
 ```bash
@@ -198,14 +192,14 @@ The following flow is proposed. `Router::pick()` is the `EndpointPicker` trait m
 
 ```text
 Router::pick()                             epp.rs
- ├─ GATE A                                 epp.rs      (1)
+ ├─ GATE A request-blind shedding          epp.rs      (1)
  ├─ tokenize                               epp.rs
  ├─ Router::route_prefill()                epp.rs       thin wrapper
  │    └─ PrefillRouter::…                  kv-router    unchanged
  ├─ Router::route_decode()                 epp.rs       thin wrapper
  │    └─ KvRouter::find_best_match()       kv-router    unchanged
  │         → (worker, overlap_blocks)
- ├─ GATE B                                 epp.rs      (2)  ← new
+ ├─ GATE B request-aware shedding          epp.rs      (2)  ← new
  ├─ resolve the worker endpoint            epp.rs
  └─ Router::add_request()                  epp.rs       bookkeeping
       └─ KvRouter::add_request()           kv-router    unchanged
@@ -213,7 +207,7 @@ Router::pick()                             epp.rs
 
 1. **GATE A** — basic, request-blind shedding, already implemented in
    [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865). Not a plugin. It runs
-   before tokenization, so it costs nothing to refuse a fully saturated pool.
+   before tokenization, so it costs nothing to refuse a fully saturated pool. Every worker is continuously marked overloaded-or-not based on how full its KV cache and prefill queue are versus a fixed threshold, and Gate A rejects the incoming request with 429 only when every worker eligible to serve it is currently marked overloaded. Dynamo's frontend already sheds load (HTTP 529); the GAIE path needs the same, made extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers pressing on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity. The beginning of its implementation is in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry over: `POST`/`GET /busy_threshold` returns thresholds per model on a live fleet, whereas the EPP reads env vars once at startup. Closing that is out of scope here.
 2. **GATE B** — the new class-aware shedding, exposed as a plugin. It sits after
    selection so it can derive uncached ISL from `overlap_blocks`, and before
    `add_request`, so nothing is booked yet and a rejection needs no rollback.

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -96,6 +96,14 @@ ext_proc request
 This mirrors the useful part of the llm-d / GAIE flow (PrepareData, then
 admission, then scheduling) without the surrounding machinery.
 
+```
+Parse body → Build LLMRequest → Admission (flow control)
+    → PrepareData plugins  ← tokenization runs here
+    → Admission plugins
+    → Scheduler (Filter → Score → Pick)
+    → PreRequest plugins → route to model server
+```
+
 ## What becomes pluggable, and what does not
 
 | Stage | Pluggable now? | Rationale |
@@ -125,6 +133,7 @@ are not making parsing, scoring, or picking pluggable at this time.
   stops the request.
 * The scheduler then runs unchanged, consuming the token data that PrepareData
   produced.
+* We should also reconsider how to do priority scheduling to decide if we want to align with GAIE. See related [proposal](https://github.com/ai-dynamo/enhancements/pull/90/changes)
 
 ## Configuration
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -160,7 +160,7 @@ Today the shed decision is funtion_of(worker_state). The client wants function_o
 
 The router side already has some of the machinery. The KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket, bucketing on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length.
 But it drives queueing, and the shed path never calls it. They're also in different crates: classification in dynamo-kv-router, shed threshold in dynamo-llm's monitor. We need to use the classifier from the kv router. 
-The classifier itself is implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, which cannot be derived from the request alone. Overlap is a property of the prompt's block hashes walked against the KV index, not a property of worker state, so no amount of background monitoring produces it — the index has to be queried for this specific prompt. Today that query happens inside the routing call, whereas Gate A runs before the body is even decoded. 
+The classifier itself is implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, which cannot be derived from the request alone. Overlap is a property of the prompt's block hashes walked against the KV index, not a property of worker state, so no amount of background monitoring produces it — the index has to be queried for this specific prompt. Today that query happens inside the routing call, whereas shedding needs to run before the routing ideally.
 
 ```bash
 pub fn resolve_class_index(&self, requested: Option<&str>, uncached_tokens: usize) -> usize {
@@ -218,7 +218,7 @@ Only a policy that actually wants uncached ISL pays for a second query, and it p
 knowingly. Moving the gate after the scheduler instead would impose the reordering on
 every deployment, whether or not it used a class-aware policy.
 
-Alt 4 proposes the opposite arrangement — placing the class-aware shed inside the router,
+Alt 1 proposes the opposite arrangement — placing the class-aware shed inside the router,
 where classification already sees accurate uncached ISL — which would remove the need for
 the advisory query and for a gateway-side Admitter altogether. It is open rather than
 rejected, and the choice between it and the arrangement below should be made before
@@ -244,9 +244,9 @@ Router::pick()                             epp.rs
       └─ KvRouter::add_request()           kv-router    unchanged
 ```
 
-1. **GATE A** — basic, request-blind shedding, already implemented in
+1. **GATE A** - basic, request-blind shedding, already implemented in
    [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865). Not a plugin. It runs
-   before tokenization, so it costs nothing to refuse a fully saturated pool. Every worker is continuously marked overloaded-or-not based on how full its KV cache and prefill queue are versus a fixed threshold, and Gate A rejects the incoming request with 429 only when every worker eligible to serve it is currently marked overloaded. Dynamo's frontend already sheds load (HTTP 529); the GAIE path needs the same, made extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers pressing on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity. The beginning of its implementation is in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry over: `POST`/`GET /busy_threshold` returns thresholds per model on a live fleet, whereas the EPP reads env vars once at startup. Closing that is out of scope here.
+   before tokenization, so it costs nothing to refuse a fully saturated pool. Every worker is continuously marked overloaded-or-not based on how full its KV cache and prefill queue are versus a fixed threshold, and Gate A rejects the incoming request with 429 only when every worker eligible to serve it is currently marked overloaded. Dynamo's frontend already sheds load (HTTP 529); the GAIE path needs the same, made extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers want on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity. The beginning of its implementation is in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry over: `POST`/`GET /busy_threshold` returns thresholds per model on a live fleet, whereas the EPP reads env vars once at startup. Closing that is out of scope here.
 2. **GATE B** — the new class-aware shedding, exposed as a plugin, occupying the Admitter
    position: after tokenization, before the scheduler. It rejects before anything is
    booked, so a rejection has nothing to roll back — the advisory query reserves no
@@ -310,25 +310,11 @@ llm-d admits in two distinct places:
   *curve* (`UsageLimitPolicy`), and the *order* (`FairnessPolicy`,
   `OrderingPolicy`) are plugins.
 * **`Admitter` plugins** run after `DataProducer` and before scheduling, and these
-  *can* reject outright. The `latency-slo-admitter`plugin is an example here.
+  *can* reject. The `latency-slo-admitter`plugin is an example here.
 
 The load-shedding plugin proposed here is that `Admitter`: same pipeline position, same
 ordering relative to data preparation, same ability to reject. That correspondence is the
 reason the seam sits where it does.
-
-One difference in the *policies* is worth noting, because it explains why this DEP needs a
-mechanism upstream does not. llm-d's `latency-slo-admitter` keys on facts that arrive with
-the request — SLO class and priority — plus a fleet-level saturation signal, so every
-input is available at ingress. Dynamo's class is derived partly from request *cost*, and
-the honest cost measure is uncached ISL, which requires querying the KV index for that
-specific prompt. Keeping the Admitter at the same pipeline position while still supporting
-a cost-derived class is what the advisory query above buys: the plugin reaches for overlap
-when its policy needs it, rather than the pipeline reordering itself for every deployment.
-
-
-The upstream split between the saturation *signal* and the admit/reject *decision*
-is a refinement this DEP does not currently make — it proposes one plugin that
-does both. This is TBD.
 
 ## What becomes pluggable, and what does not
 
@@ -430,8 +416,7 @@ The two boundaries answer different questions and should stay that way:
 
 Shedding at the edge and queueing in the scheduler are complements: the edge is where
 you cheaply refuse work you should never start, and the scheduler is where you hold
-work that is worth waiting for. Building a third mechanism to span them would be a
-mistake.
+work that is worth waiting for. 
 
 
 ## Configuration
@@ -491,11 +476,6 @@ loading in this first cut.
   response path — but it is adjacent in-flight work in the same crate, and it supplies
   the observed cache hit that integrators want for comparing predicted overlap against
   actual, which this DEP treats as router work rather than an extension point.
-
-The two are complements, not overlaps: #11865 reads worker capacity on the request
-path to decide whether to admit, and #11868 reads request outcome on the response
-path after the decision is already made. They do touch the same files, so whichever
-lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 
 # Alternate Solutions
 
@@ -563,15 +543,6 @@ its uncached token count is the core change.
   saturated case.
 
 **Open — not yet rejected.** 
-
-There is also a coordination risk. `lib/kv-router/src/scheduling/queue_admission/` is
-described as the established boundary for policy-class admission algorithms, but the
-module currently contains only `RequestProgress` and `WorkerPlacement` — the contract is
-designed and unbuilt, and its decision set is `Bypass` / `Ready` / `Defer` with no
-`Reject`. Alt 4 amounts to adding `Reject` to that contract, so it likely belongs folded
-into whichever proposal owns it rather than pursued from the EPP side. Identify that
-owner before choosing between Alt 4 and the main proposal.
-
 
 ## Alt 2 Reproduce the full llm-d / GAIE plugin pipeline in Rust
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -35,12 +35,13 @@ the Rust EPP becomes the single EPP and must absorb the extensibility that
 previously only existed in Go.
 
 This proposal adds a minimal extension model to the Rust EPP: **two plugin points and
-one shared input**. The plugins are **PrepareData** (per-request data preparation before
-scheduling; tokenization is the first use) and **load shedding / admission** (reject
-a request under overload before scheduling). The shared input is a read-only
+one shared input**. The plugins are **DataProducer** (per-request data preparation before
+scheduling; tokenization is the first use) and ** Admitter (load shedding) ** (reject
+a request under overload before scheduling). 
+
+The shared input is a read-only
 **worker-state view** — the KV and prefill load signal that overload decisions
-actually depend on — exposed once at the extension boundary instead of being
-rebuilt privately by every implementation. Everything else — parsing, the KV-aware
+actually depend on — exposed once at the extension boundary. Everything else — parsing, the KV-aware
 scheduler/picker, and bookkeeping — stays built in. We deliberately do not reproduce
 the full llm-d pipeline.
 
@@ -69,7 +70,7 @@ policy must fork it. Three concrete needs drive this proposal:
   It belongs inside the EPP and users want to supply their own policy. Dynamo's
   frontend already sheds load (HTTP 529); the GAIE path needs the same, made
   extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers pressing on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity.
-  The *built-in* half of this is in flight in
+  The *built-in* half of this is in
   [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which
   reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated
   { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry
@@ -84,11 +85,8 @@ policy must fork it. Three concrete needs drive this proposal:
 
 ## Goals
 
-* Provide exactly two extension points in the Rust EPP: PrepareData and load
-  shedding / admission.
-* Expose one read-only worker-state view as a first-class input, consumed by the
-  built-in shedder and available to any plugin, so policy state has a single source
-  of truth.
+* Provide extension points in the Rust EPP: DataProducer and Admitter.
+* Expose one read-only worker-state view as a first-class input available to any plugin, so policy state has a single source of truth.
 * Move today's inline tokenization behind the default PrepareData plugin with no
   behavior change.
 * Ship a default load-shedding plugin that reuses the frontend's saturation /
@@ -115,15 +113,12 @@ policy must fork it. Three concrete needs drive this proposal:
   and giving the EPP a back door into them would create exactly the coupling the
   first non-goal avoids. They belong to the router and its policy-class admission
   API.
-* DataProducer dependency graphs, fairness / priority-band queues, request
-  eviction, or the `flowControl` feature gate from llm-d.
 * Dynamic plugin loading (`.so` / WASM).
 * Any dependency on the deprecated Go EPP or its config schema.
 
 ## Requirements
 
-These come from a production integrator running the Rust EPP behind agentgateway,
-who intends to supply their own load-shedding and prioritization policy. Their
+These come from clients who intend to supply their own load-shedding and prioritization policy. Their
 framing is worth recording because it narrows the design: for them load shedding is
 primarily a *routing signal* — a fast explicit rejection that failover can act on,
 replacing implicit shed-by-timeout that wastes prefill compute — and prioritization
@@ -131,8 +126,8 @@ is about retry-versus-first-attempt and request size, not tenant tiers.
 
 ### REQ 1 Worker state as a first-class input
 
-Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to the extension boundary rather than something each policy derives itself. Note that of these, KV blocks and prefill tokens are tracked today; queue depth is not, and this DEP proposes exposing what exists rather than adding a
-new signal. **Not yet met.**
+Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to plugins rather than something each policy derives itself. Note that of these, KV blocks and prefill tokens are tracked today; queue depth is not, and this DEP proposes exposing what exists rather than adding a
+new signal. 
 
 
 ### REQ 2 Shed semantics distinguishable from failure
@@ -187,9 +182,9 @@ scheduler, both reading one shared worker-state view:
                                         worker-state view (read-only, shared)
                                              |            |
 ext_proc request                             v            v
-  -> parse body / build request         (built in)
-  -> PrepareData plugin                  (pluggable)  <-- tokenization lives here
-  -> Load-shedding / admission plugin    (pluggable)  <-- reject under overload
+  -> parse body / build request          (built in)
+  -> DataProducer plugin                 (pluggable)  <-- tokenization lives here
+  -> Admitter (Load-shedding) plugin     (pluggable)  <-- reject under overload
   -> Scheduler: pick worker              (built in, existing KV router)
   -> attach routing headers / tokens     (built in)
   -> return decision to Envoy
@@ -200,7 +195,7 @@ This mirrors the useful part of the llm-d / GAIE flow (PrepareData, then
 admission, then scheduling) without the surrounding machinery.
 
 ```
-Parse body → Build LLMRequest → Admission (flow control)   ← builtin, not pluggable
+Parse body → Build LLMRequest → Flow control   ← builtin, not pluggable
     → DataProducer plugins   ← tokenization runs here
     → Admitter plugins       ← can reject
     → Scheduler (Filter → Score → Pick)
@@ -209,9 +204,7 @@ Parse body → Build LLMRequest → Admission (flow control)   ← builtin, not 
 
 ### Alignment with llm-d's two admission layers
 
-llm-d admits in two distinct places. The distinction is easy to miss because both
-are called "admission", and it is worth naming here because it is what makes this
-DEP's single shedding seam a deliberate choice rather than an arbitrary one:
+llm-d admits in two distinct places:
 
 * **Flow control** runs first and is a *builtin*. Capacity rejection
   (`maxBytes` / `maxRequests`), TTL eviction, and priority-band traversal are
@@ -222,24 +215,16 @@ DEP's single shedding seam a deliberate choice rather than an arbitrary one:
   *curve* (`UsageLimitPolicy`), and the *order* (`FairnessPolicy`,
   `OrderingPolicy`) are plugins.
 * **`Admitter` plugins** run after `DataProducer` and before scheduling, and these
-  *can* reject outright. `latency-slo-admitter` ships in-tree.
+  *can* reject outright. The `latency-slo-admitter`plugin is an example here.
 
 The load-shedding plugin proposed here is the `Admitter`: same pipeline position,
 same ordering relative to data preparation, same ability to reject. That
 correspondence is the reason the seam sits where it does.
 
-Excluding the flow-control layer (see Non Goals) is therefore not in tension with
-making shedding pluggable — upstream does not make that layer pluggable either.
-Dynamo's existing generic sheds are the local equivalent of it and stay as they
-are: the per-class caps enforced by `queue_rejection()` in `policy_queue.rs`, the
-EPP's in-flight semaphore (`DYN_EPP_MAX_INFLIGHT_REQUESTS`), and the worker engine
-request limit.
 
 The upstream split between the saturation *signal* and the admit/reject *decision*
 is a refinement this DEP does not currently make — it proposes one plugin that
-does both. Whether to split them is worth settling alongside REQ 1, since making
-the signal itself the seam would turn "one source of truth for overload" from a
-convention into a structural property.
+does both. This is TBD.
 
 ## What becomes pluggable, and what does not
 
@@ -247,8 +232,8 @@ convention into a structural property.
 |-------|----------------|-----------|
 | `ext_proc` protocol / server | No | Transport; not a policy decision |
 | Parse body / build request | No | Stable, shared parsing |
-| PrepareData (tokenization) | Yes | Users need different tokenizers; enables prefix-cache routing and tokens-in forwarding |
-| Load shedding (admission) | Yes | Users need their own overload policy |
+| DataProducer (tokenization) | Yes | Users need different tokenizers; enables prefix-cache routing and tokens-in forwarding |
+| Admitter (Load shedding) | Yes | Users need their own overload policy |
 | Worker-state view | No — read-only input | Not a stage. One shared source of truth for the signals policies need (REQ 1) |
 | Scheduler (worker pick) | No (for now) | The existing KV-aware router stays the default; can be revisited later |
 | Bookkeeping / headers | No | Internal correctness |
@@ -261,12 +246,12 @@ pluggable at this time.
 ## How the plugins work (conceptually)
 
 * A plugin is a small piece of user code selected by name in configuration.
-* **PrepareData** plugins run first and can attach prepared data (starting with
+* **DataProducer** plugins run first and can attach prepared data (starting with
   token IDs / multimodal metadata) to the request. Tokenization ships as the
   default PrepareData plugin. If token data is already present (e.g. a pre-tokenized
   request), the plugin is skipped. PrepareData is fail-open: if a plugin errors, the
   request still proceeds and scheduling falls back to prompt-based behavior.
-* **Load-shedding** plugins run next and default to allow: each plugin may reject
+* **Admitter (Load-shedding)** plugins run next and default to allow: each plugin may reject
   (mapped to HTTP 429 / 503, with 529 available for Dynamo clients); if none
   reject, the request proceeds. Multiple plugins can be chained and any rejection
   stops the request.
@@ -277,13 +262,9 @@ pluggable at this time.
 ## Worker state as a first-class input
 
 A load-shedding plugin is only as good as what it can see. Today the EPP computes the
-overload signal in `KvWorkerMonitor` and keeps it private to the concrete router, so
-a plugin would either be handed a pre-baked boolean or have to build its own feed. The
-first is not a policy seam; the second duplicates plumbing and creates a second
-source of truth that can disagree with the built-in shedder.
-
-None of this is new data. `KvWorkerMonitor` already holds
-`worker_load_states: Arc<DashMap<u64, WorkerLoadState>>`, kept current by its own
+overload signal in `KvWorkerMonitor` and keeps it private to the concrete router. 
+`KvWorkerMonitor` already holds `worker_load_states: Arc<DashMap<u64, WorkerLoadState>>`, 
+kept current by its own
 background task against the Dynamo runtime and already recomputing the derived
 overloaded set on every update. There is nothing to fetch: the gap is that this `Arc`
 is a private field and the trait boundary has no parameter to pass it through. The
@@ -291,34 +272,55 @@ cheap fix is for the monitor to publish an immutable snapshot into a `watch` cha
 a pattern it already uses internally — so the update path pays the cost and each
 decision takes one refcount bump rather than a map traversal.
 
-Instead, the same state the built-in shedder consumes is exposed once, read-only, at
-the extension boundary:
+For the Admitter the following data is needed. Upstream needs the same class of input:
+llm-d's only shipping admitter, `latency-slo-admitter`, reads `KVCacheUsagePercent`
+from endpoint metrics and `DispatchedRequestCount` from endpoint attributes, and admits
+a sheddable request when any endpoint is idle or cold. Same question, same kind of
+per-endpoint load data.
 
-* **Per-worker load**, in the terms the thresholds are already expressed in: active
-  decode blocks and KV used blocks against `kv_total_blocks`, and active prefill
-  tokens against `max_num_batched_tokens`, per dp_rank. Queue depth is *not* part of
-  this set today; adding it would be a deliberate extension of the view, not an
-  assumed member of it.
-* **The derived overloaded-worker set**, so a policy can ask the cheap question
-  ("is anything free?") without recomputing the expensive one — and, more
-  importantly, get the same latched answer the built-in shedder acts on rather than
-  an unlatched approximation of it.
-* **A distinction between structurally eligible and currently available workers**,
-  matching the split the router's admission contract already makes, so a policy can
-  tell "no worker can ever serve this" from "every worker is busy right now."
+**1. Raw per-worker load.** The same numbers the built-in thresholds compare against,
+per worker and per dp_rank: `active_decode_blocks` and `kv_used_blocks` against
+`kv_total_blocks`, and `active_prefill_tokens` against `max_num_batched_tokens`. A
+plugin that wants a different rule — shed at 70% instead of 85%, or weigh prefill
+pressure differently — reads these and decides for itself. Queue depth is
+deliberately absent: nothing tracks a per-worker pending count today, so adding it
+would be a separate change rather than something to assume is available.
 
-Three properties keep this from turning into a scoring API. The view is **read-only**:
-a policy observes, it does not mutate router state. It is a **snapshot** with a
-consistent view across a single decision, not a live handle that invites a policy to
-poll in a loop. And it is **typed and narrow** — named accessors for signals we
-already maintain, not a metadata bag — so adding a fact is a deliberate act and the
-boundary stays reviewable.
+**2. The precomputed overloaded-worker set.** Which workers are currently too busy. A
+plugin uses this to decide whether to admit the request. If some workers are free, it
+admits and lets normal routing pick one. If they are all busy, the plugin decides what
+to do with *this* request — for example reject low-priority traffic with 429 and
+`Retry-After` but let high-priority traffic through. That per-request choice is the
+point, since the built-in shedder is all-or-nothing.
 
-This is what makes the decorator authoring model honest. Wrapping the stock router
-in an outer policy already works mechanically — the trait is a normal Rust trait and
-the server is generic over it — but a wrapper that cannot see load can only reject
-blindly or reorder what comes back. With the state view it can make the same class
-of decision the built-in shedder makes, which is the whole point of the seam.
+**3. Structurally eligible versus currently available workers.** Two sets, matching
+the split `WorkerEligibilitySnapshot` already makes in the router's admission
+contract:
+
+* No structurally eligible worker means nothing in the fleet can ever serve this
+  request. Retrying will not help.
+* Structurally eligible but none available means every capable worker is busy right
+  now. Retrying will help.
+
+This distinction decides what the gateway gets told, which makes it load bearing for
+REQ 2: only the second case should become 429 with `Retry-After`. The first is a
+permanent failure, and attaching a retry hint to it actively misleads the gateway's
+failover logic. A policy that cannot see both sets cannot tell the two apart.
+
+### What keeps this from becoming a scoring API which we do not want to chage
+
+Exposing state is not the same as making selection pluggable, which stays a Non Goal.
+Three properties hold that line:
+
+* **Read-only.** A plugin observes. It cannot mark a worker overloaded, retune a
+  threshold, or touch the KV index, so it has no way to steer selection through the
+  state view.
+* **A snapshot, not a live handle.** One frozen picture per decision, so two reads
+  within a single decision agree and there is nothing to poll in a loop. It is also
+  cheap to pass: a refcount bump rather than a map traversal.
+* **Typed and narrow.** Named accessors for signals we already maintain, not a
+  `HashMap<String, Value>`. Adding a fact becomes a reviewable code change instead of
+  a plugin quietly depending on a key nobody knew existed.
 
 ## Relationship to the router's policy-class admission API
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -190,17 +190,16 @@ router changes at all:
    class for a request then disagrees with the router's, so one request can be a
    "small" shed class and a "large" queue class at the same time — the two-sources-of-
    truth problem this DEP objects to elsewhere, in a new place.
-2. **Move the shed gate after tokenization and the overlap query.** No router change,
-   and class identity stays consistent, but it gives up the cheap pre-parse refusal
-   that distinguishes the EPP's shed from the frontend's error-driven one.
-3. **Push the decision into the router**, where uncached tokens and class assignment
+2. **Move the shed gate after tokenization.** We can feed raw prompt tokens as the size proxy to uncached_isl_buckets. But this would be counter-productive for the purpose. Raw ISL would systematically over-estimate cost on that traffic, so a mostly-cached large request would land in the "oversized" bucket and get shed — the precise mis-classification his design exists to prevent.
+3. **Move the gate after overlap sampling**. We will use true uncached ISL but have to run the query `find_matches on the indexer`. We will pay with time for the index query on a request we may to reject. But this extra cost is minor compared to the cost of tokenization. 
+4. **Push the decision into the router**, where uncached tokens and class assignment
    already sit together. This is the only option requiring a router contract change:
    `AdmissionDecision` is `Bypass | Ready | Defer` today, with no rejection variant, so
    the policy-class admission API can hold a request indefinitely but cannot shed one.
 
 The per-class thresholds should be configured in the router's policy YAML — which already carries a
 per-class `admission:` envelope rather than in EPP environment variables, since
-splitting class definitions from class thresholds invites drift.
+splitting class definitions from class thresholds invites drift. `RouterPolicyConfig::from_yaml`, `resolve_profile`, `PolicyProfile`, and both class-index methods are all public, so the EPP can use them. But `KvRouterConfig::loaded_policy_config()` is private, so the EPP either gets that made public or loads the YAML itself.
 
 This DEP does not pick one yet; the choice should be made before implementation starts.
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -485,7 +485,7 @@ Put the shed decision where classification already happens — inside `dynamo-kv
 scheduling path — instead of adding an Admitter plugin at the gateway. The EPP then
 contributes only the parts that are genuinely HTTP-shaped: an overload signal, a mapping
 from request headers to `policy_class`, and the translation of a rejection into 429 with
-`Retry-After`. 
+`Retry-After`. See this [WIP PR](https://github.com/ai-dynamo/dynamo/pull/12663)
 
 Most of the machinery for this already exists:
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -1,0 +1,192 @@
+# Make the Dynamo Rust EPP Extensible (PrepareData + Load Shedding)
+
+**Status**: Draft
+
+**Authors**: [atchernych](https://github.com/atchernych)
+
+**Category**: Architecture
+
+**Replaces**: N/A
+
+**Replaced By**: N/A
+
+**Sponsor**: [TBD — assign a code owner / maintainer]
+
+**Required Reviewers**: [TBD — inference-gateway / EPP owners]
+
+**Review Date**: [TBD]
+
+**Pull Request**: [TBD — link to this PR in ai-dynamo/enhancements]
+
+**Implementation PR / Tracking Issue**: [TBD — link to ai-dynamo/dynamo tracking issue]
+
+# Summary
+
+The Dynamo Rust EPP (`dynamo-ext-proc`) today is effectively two things: the
+Envoy `ext_proc` server and a single, hard-wired router that tokenizes the
+prompt and picks a worker. There are no extension points. The Go EPP — which
+follows the GAIE / llm-d pipeline and supports plugins — is being deprecated, so
+the Rust EPP becomes the single EPP and must absorb the extensibility that
+previously only existed in Go.
+
+This proposal adds a minimal, two-hook extension model to the Rust EPP so users
+can supply their own code at exactly two points: **PrepareData** (per-request
+data preparation before scheduling; tokenization is the first use) and **load
+shedding / admission** (reject a request under overload before scheduling).
+Everything else — parsing, the KV-aware scheduler/picker, and bookkeeping —
+stays built in. We deliberately do not reproduce the full llm-d pipeline.
+
+# Motivation
+
+The Go EPP is being deprecated, and its plugin-based extensibility goes away with
+it. The Rust EPP cannot currently be extended: all logic lives in one router
+implementation, so users who want custom tokenization or custom load-shedding
+policy must fork it. Two concrete needs drive this proposal:
+
+- **Tokenization must be swappable.** Different deployments tokenize differently
+  (in-process, vLLM `/render`, estimate/byte-packing). llm-d moved tokenized
+  prompt data into a dedicated, plugin-populated field on the request for exactly
+  this reason; the Rust EPP should have an equivalent seam instead of hard-coding
+  one tokenizer. Structured token data also enables accurate prefix-cache routing
+  and future tokens-in forwarding to model servers.
+- **Load shedding must be pluggable and LLM-aware.** Overload protection for LLM
+  serving must look at KV-cache and queue saturation, not generic request rate.
+  It belongs inside the EPP and users want to supply their own policy. Dynamo's
+  frontend already sheds load (HTTP 529); the GAIE path needs the same, made
+  extensible.
+
+## Goals
+
+* Provide exactly two extension points in the Rust EPP: PrepareData and load
+  shedding / admission.
+* Move today's inline tokenization behind the default PrepareData hook with no
+  behavior change.
+* Ship a default load-shedding hook with parity to the frontend's
+  saturation / busy-threshold behavior.
+* Keep the architecture simple; an unconfigured Rust EPP behaves as it does
+  today.
+* Allow users to add hooks via compile-time registration in a custom Rust EPP
+  binary/image.
+
+### Non Goals
+
+* Pluggable scorers, pickers, or profile handlers. This interface depends on the Dynamo Router and the change has to come with the change in its interfaces. 
+* DataProducer dependency graphs, fairness / priority-band queues, request
+  eviction, or the `flowControl` feature gate from llm-d.
+* Dynamic plugin loading (`.so` / WASM).
+* Any dependency on the deprecated Go EPP or its config schema.
+
+# Proposal
+
+## Overview
+
+Keep the existing request flow and insert two hook points around the existing
+scheduler:
+
+```
+ext_proc request
+  -> parse body / build request        (built in)
+  -> PrepareData hook                   (pluggable)  <-- tokenization lives here
+  -> Load-shedding / admission hook     (pluggable)  <-- reject under overload
+  -> Scheduler: pick worker             (built in, existing KV router)
+  -> attach routing headers / tokens    (built in)
+  -> return decision to Envoy
+```
+
+This mirrors the useful part of the llm-d / GAIE flow (PrepareData, then
+admission, then scheduling) without the surrounding machinery.
+
+## What becomes pluggable, and what does not
+
+| Stage | Pluggable now? | Rationale |
+|-------|----------------|-----------|
+| `ext_proc` protocol / server | No | Transport; not a policy decision |
+| Parse body / build request | No | Stable, shared parsing |
+| PrepareData (tokenization) | Yes | Users need different tokenizers; enables prefix-cache routing and tokens-in forwarding |
+| Load shedding (admission) | Yes | Users need their own overload policy |
+| Scheduler (worker pick) | No (for now) | The existing KV-aware router stays the default; can be revisited later |
+| Bookkeeping / headers | No | Internal correctness |
+
+The Rust EPP is currently `ext_proc` + scheduler; this proposal adds exactly two
+pluggable stages in front of the scheduler and leaves the scheduler built in. We
+are not making parsing, scoring, or picking pluggable at this time.
+
+## How the hooks work (conceptually)
+
+* A hook is a small piece of user code selected by name in configuration.
+* **PrepareData** hooks run first and can attach prepared data (starting with
+  token IDs / multimodal metadata) to the request. Tokenization ships as the
+  default PrepareData hook. If token data is already present (e.g. a pre-tokenized
+  request), the hook is skipped. PrepareData is fail-open: if a hook errors, the
+  request still proceeds and scheduling falls back to prompt-based behavior.
+* **Load-shedding** hooks run next and default to allow: each hook may reject
+  (mapped to HTTP 429 / 503, with 529 available for Dynamo clients); if none
+  reject, the request proceeds. Multiple hooks can be chained and any rejection
+  stops the request.
+* The scheduler then runs unchanged, consuming the token data that PrepareData
+  produced.
+
+## Configuration
+
+The Rust EPP gets a small, self-contained config (a mounted file / env var read
+at startup) with just two things: which PrepareData hook to use, and an ordered
+list of load-shedding hooks to run. No CRD and no dependency on the Go EPP's
+config schema. Built-in hooks (a default tokenizer and a default
+saturation / busy-threshold shedder) are always available; users select their own
+by name. Sensible defaults mean an unconfigured Rust EPP behaves as it does
+today.
+
+## User authoring model (compile-time)
+
+Users implement a hook in Rust, register it by name, and build a custom Rust EPP
+binary that links the framework plus their hook, then publish that image and
+point the GAIE `InferencePool` at it. This is compile-time only — no dynamic
+loading in this first cut.
+
+## Delivery outline
+
+1. Introduce the two hook points in the Rust EPP and move today's inline
+   tokenization behind the default PrepareData hook (no behavior change).
+2. Add a default load-shedding hook (saturation / busy-threshold parity with the
+   frontend) and the config plumbing to select / chain hooks.
+3. Document the authoring model and ship one example custom hook alongside the
+   existing GAIE docs.
+
+# Alternate Solutions
+
+## Alt 1 Reproduce the full llm-d / GAIE plugin pipeline in Rust
+
+**Pros:**
+
+* Maximum flexibility (pluggable scorers, pickers, profile handlers, fairness,
+  flow control).
+* Closer 1:1 mapping to the Go EPP and upstream GAIE.
+
+**Cons:**
+
+* Large surface area and ongoing maintenance for extension points nobody is
+  asking for yet.
+* Slower to deliver the two capabilities actually needed.
+
+**Reason Rejected:**
+
+* Over-engineered for current needs. The two hooks cover the real use cases
+  (custom tokenizer, custom overload policy). Additional extension points can be
+  proposed later if a concrete need appears.
+
+## Alt 2 Keep load shedding / tokenization out of the EPP (gateway-level only)
+
+**Pros:**
+
+* No EPP changes.
+
+**Cons:**
+
+* Generic gateway RPS limits are a poor proxy for KV-cache / queue saturation.
+* Tokenization for prefix-cache routing has to happen where routing decisions are
+  made.
+
+**Reason Rejected:**
+
+* Both capabilities are inherently LLM-aware and belong in the EPP, consistent
+  with llm-d and Dynamo's own frontend admission behavior.

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -34,8 +34,8 @@ follows the GAIE / llm-d pipeline and supports plugins — is being deprecated, 
 the Rust EPP becomes the single EPP and must absorb the extensibility that
 previously only existed in Go.
 
-This proposal adds a minimal extension model to the Rust EPP: **two hooks and one
-shared input**. The hooks are **PrepareData** (per-request data preparation before
+This proposal adds a minimal extension model to the Rust EPP: **two plugin points and
+one shared input**. The plugins are **PrepareData** (per-request data preparation before
 scheduling; tokenization is the first use) and **load shedding / admission** (reject
 a request under overload before scheduling). The shared input is a read-only
 **worker-state view** — the KV and prefill load signal that overload decisions
@@ -94,15 +94,15 @@ policy must fork it. Three concrete needs drive this proposal:
 * Provide exactly two extension points in the Rust EPP: PrepareData and load
   shedding / admission.
 * Expose one read-only worker-state view as a first-class input, consumed by the
-  built-in shedder and available to any hook, so policy state has a single source
+  built-in shedder and available to any plugin, so policy state has a single source
   of truth.
-* Move today's inline tokenization behind the default PrepareData hook with no
+* Move today's inline tokenization behind the default PrepareData plugin with no
   behavior change.
-* Ship a default load-shedding hook with parity to the frontend's
+* Ship a default load-shedding plugin with parity to the frontend's
   saturation / busy-threshold behavior.
 * Keep the architecture simple; an unconfigured Rust EPP behaves as it does
   today.
-* Allow users to add hooks via compile-time registration in a custom Rust EPP
+* Allow users to add plugins via compile-time registration in a custom Rust EPP
   binary/image.
 
 ### Non Goals
@@ -153,7 +153,7 @@ gateway, with a retry hint. **Met by
 { retry_after_secs }` → HTTP 429 with `Retry-After`. Because it is an ordinary error
 variant, an out-of-tree policy can return it too.
 
-### REQ 3 Response usage on the completion hook
+### REQ 3 Response usage on the completion callback
 
 The terminal response's token usage — at minimum
 `usage.prompt_tokens_details.cached_tokens` — must reach the picker so a deployment
@@ -190,20 +190,20 @@ side already has most of the machinery; see the division of labor below.
 
 ## Overview
 
-Keep the existing request flow and insert two hook points around the existing
+Keep the existing request flow and insert two plugin points around the existing
 scheduler, both reading one shared worker-state view:
 
 ```
                                         worker-state view (read-only, shared)
-                                            |            |
-ext_proc request                            v            v
-  -> parse body / build request        (built in)
-  -> PrepareData hook                   (pluggable)  <-- tokenization lives here
-  -> Load-shedding / admission hook     (pluggable)  <-- reject under overload
-  -> Scheduler: pick worker             (built in, existing KV router)
-  -> attach routing headers / tokens    (built in)
+                                             |            |
+ext_proc request                             v            v
+  -> parse body / build request         (built in)
+  -> PrepareData plugin                  (pluggable)  <-- tokenization lives here
+  -> Load-shedding / admission plugin    (pluggable)  <-- reject under overload
+  -> Scheduler: pick worker              (built in, existing KV router)
+  -> attach routing headers / tokens     (built in)
   -> return decision to Envoy
-  -> response hooks                     (built in)  <-- prefill complete, usage
+  -> response callbacks                  (built in)  <-- prefill complete, usage
 ```
 
 This mirrors the useful part of the llm-d / GAIE flow (PrepareData, then
@@ -234,17 +234,17 @@ pluggable stages in front of the scheduler, one read-only input feeding them, an
 leaves the scheduler built in. We are not making parsing, scoring, or picking
 pluggable at this time.
 
-## How the hooks work (conceptually)
+## How the plugins work (conceptually)
 
-* A hook is a small piece of user code selected by name in configuration.
-* **PrepareData** hooks run first and can attach prepared data (starting with
+* A plugin is a small piece of user code selected by name in configuration.
+* **PrepareData** plugins run first and can attach prepared data (starting with
   token IDs / multimodal metadata) to the request. Tokenization ships as the
-  default PrepareData hook. If token data is already present (e.g. a pre-tokenized
-  request), the hook is skipped. PrepareData is fail-open: if a hook errors, the
+  default PrepareData plugin. If token data is already present (e.g. a pre-tokenized
+  request), the plugin is skipped. PrepareData is fail-open: if a plugin errors, the
   request still proceeds and scheduling falls back to prompt-based behavior.
-* **Load-shedding** hooks run next and default to allow: each hook may reject
+* **Load-shedding** plugins run next and default to allow: each plugin may reject
   (mapped to HTTP 429 / 503, with 529 available for Dynamo clients); if none
-  reject, the request proceeds. Multiple hooks can be chained and any rejection
+  reject, the request proceeds. Multiple plugins can be chained and any rejection
   stops the request.
 * The scheduler then runs unchanged, consuming the token data that PrepareData
   produced.
@@ -252,9 +252,9 @@ pluggable at this time.
 
 ## Worker state as a first-class input
 
-A load-shedding hook is only as good as what it can see. Today the EPP computes the
+A load-shedding plugin is only as good as what it can see. Today the EPP computes the
 overload signal in `KvWorkerMonitor` and keeps it private to the concrete router, so
-a hook would either be handed a pre-baked boolean or have to build its own feed. The
+a plugin would either be handed a pre-baked boolean or have to build its own feed. The
 first is not a policy seam; the second duplicates plumbing and creates a second
 source of truth that can disagree with the built-in shedder.
 
@@ -299,7 +299,7 @@ and is not wired into the EPP.
 
 The two boundaries answer different questions and should stay that way:
 
-| | EPP hooks (this DEP) | Router policy-class admission |
+| | EPP plugins (this DEP) | Router policy-class admission |
 |---|---|---|
 | Scope | One request at the gateway edge | A class of requests inside the scheduler |
 | Vocabulary | Admit or reject, now | Admit, defer, release, place |
@@ -325,17 +325,17 @@ implementation question this DEP defers.
 ## Configuration
 
 The Rust EPP gets a small, self-contained config (a mounted file / env var read
-at startup) with just two things: which PrepareData hook to use, and an ordered
-list of load-shedding hooks to run. No CRD and no dependency on the Go EPP's
-config schema. Built-in hooks (a default tokenizer and a default
+at startup) with just two things: which PrepareData plugin to use, and an ordered
+list of load-shedding plugins to run. No CRD and no dependency on the Go EPP's
+config schema. Built-in plugins (a default tokenizer and a default
 saturation / busy-threshold shedder) are always available; users select their own
 by name. Sensible defaults mean an unconfigured Rust EPP behaves as it does
 today.
 
 ## User authoring model (compile-time)
 
-Users implement a hook in Rust, register it by name, and build a custom Rust EPP
-binary that links the framework plus their hook, then publish that image and
+Users implement a plugin in Rust, register it by name, and build a custom Rust EPP
+binary that links the framework plus their plugin, then publish that image and
 point the GAIE `InferencePool` at it. This is compile-time only — no dynamic
 loading in this first cut.
 
@@ -344,20 +344,20 @@ loading in this first cut.
 1. Land the built-in shedder
    ([dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865)): `KvWorkerMonitor` reuse,
    `PickError::Saturated { retry_after_secs }`, HTTP 429 with `Retry-After`.
-   Satisfies REQ 2 and gives the later hook a reference implementation.
+   Satisfies REQ 2 and gives the later plugin a reference implementation.
 2. Expose the worker-state view as a read-only input and refactor the built-in
    shedder to consume it, proving the boundary carries a real policy before any
    third party depends on it. Satisfies REQ 1.
-3. Introduce the two hook points and move today's inline tokenization behind the
-   default PrepareData hook (no behavior change).
-4. Add the config plumbing to select / chain hooks, with the built-in shedder as
-   the default load-shedding hook.
+3. Introduce the two plugin points and move today's inline tokenization behind the
+   default PrepareData plugin (no behavior change).
+4. Add the config plumbing to select / chain plugins, with the built-in shedder as
+   the default load-shedding plugin.
 5. Express shed thresholds per policy class rather than process-wide, reusing the
    router's existing class assignment. Satisfies REQ 5.
-6. Document the authoring model and ship one example custom hook alongside the
+6. Document the authoring model and ship one example custom plugin alongside the
    existing GAIE docs.
 
-Step 2 before step 3 is deliberate. Shipping hooks first would mean publishing a
+Step 2 before step 3 is deliberate. Shipping plugins first would mean publishing a
 seam whose only real policy input is still private, which is how a boundary ends up
 frozen around the wrong shape.
 
@@ -371,7 +371,7 @@ frozen around the wrong shape.
   decides whether EPP-side prioritization aligns with GAIE; REQ 5 depends on the
   outcome.
 * [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865) — "Enable load
-  shedding in the EPP" (DEP-1073). Adds the built-in shedder this DEP's default hook
+  shedding in the EPP" (DEP-1073). Adds the built-in shedder this DEP's default plugin
   is built from: `KvWorkerMonitor` reuse, `PickError::Saturated { retry_after_secs }`,
   and HTTP 429 with `Retry-After`. Satisfies REQ 2, and its private
   `WorkerLoadState` is exactly what REQ 1 proposes to expose.
@@ -404,7 +404,7 @@ lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 
 **Reason Rejected:**
 
-* Over-engineered for current needs. The two hooks plus the shared state view cover
+* Over-engineered for current needs. The two plugins plus the shared state view cover
   the real use cases (custom tokenizer, custom overload policy). Additional
   extension points can be proposed later if a concrete need appears.
 
@@ -425,7 +425,7 @@ lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 * Both capabilities are inherently LLM-aware and belong in the EPP, consistent
   with llm-d and Dynamo's own frontend admission behavior.
 
-## Alt 3 Ship the hooks without exposing worker state
+## Alt 3 Ship the plugins without exposing worker state
 
 Leave the state feed private and let each out-of-tree policy build its own — the
 `EndpointPicker` trait is already wrappable, so an integrator can decorate the stock
@@ -444,7 +444,7 @@ router and subscribe to worker events independently.
   admitted by the other — is very hard to debug from outside.
 * Duplicate plumbing in every deployment that wants a custom policy, which is the
   specific cost REQ 1 was raised to avoid.
-* The hook seam would be mostly decorative: a shedding hook that cannot see
+* The plugin seam would be mostly decorative: a shedding plugin that cannot see
   saturation can only apply request-shaped heuristics, so the interesting policies
   would still live in forks.
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -123,13 +123,13 @@ pub struct WorkerLoadState {
   Dynamo Router and the change has to come with the change in its interfaces.
   Exposing worker state as a read-only *input* (above) does not breach this: a
   policy may read the same signals the scheduler reads, and may reject or defer a
-  request, but it does not participate in scoring or selection.
+  request, but it does not participate in scoring or selection. The related proposal is 
+  reflected in these [slides](https://docs.google.com/presentation/d/1_k-ytG9QxgSUAOnLG7CZG90QM6Zjx3PvpzaI24N4_So/edit?slide=id.g3f6000d6429_0_0#slide=id.g3f6000d6429_0_0)
 * Steering the router's internal scoring from an EPP extension — for example
   zeroing a worker's prefix-overlap credit, retuning the KV indexer's TTL decay, or
-  forcing an index resync for one worker. Integrators have asked for these, and they
+  forcing an index resync for one worker. Clients have asked for these, and they
   are legitimate needs, but they are operations on the router's own state, not on the
-  EPP's request path,
-  and giving the EPP a back door into them would create exactly the coupling the
+  EPP's request path, and giving the EPP a back door into them would create exactly the coupling the
   first non-goal avoids. They belong to the router and its policy-class admission
   API.
 * Dynamic plugin loading (`.so` / WASM).
@@ -144,28 +144,45 @@ is about retry-versus-first-attempt and request size, not tenant tiers.
 
 ### REQ 1 Worker state as a first-class input
 
-Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to plugins rather than something each policy derives itself. Note that of these, KV blocks and prefill tokens are tracked today; queue depth is not, and this DEP proposes exposing in. 
+Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to plugins rather than something each policy derives itself. Note that of these, KV blocks and prefill tokens are tracked today; queue depth is not, and this DEP proposes exposing it. 
 
 
-### REQ 2 Shed semantics distinguishable from failure
+### REQ 2 New Shed semantics
 
-Rejection under overload must be distinguishable from an error and routable by the
-gateway, with a retry hint. **Met by
-[dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865)** via `PickError::Saturated
-{ retry_after_secs }` → HTTP 429 with `Retry-After`. Because it is an ordinary error
-variant, an out-of-tree policy can return it too.
+Today the FontEnd implements saturation detection and responds with http 529 error. The shedding decision outcome should not be an error or requeue inside the router, it should reside in the EPP as a custom-either retry or reject and sent to the gateway. We will use the FrontEnd logic with a change in this [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865)** via `PickError::Saturated
+{ retry_after_secs }` → HTTP 429 with `Retry-After`. 
+
 
 
 ### REQ 3 Class-aware shed thresholds
 
-Today the threshold is one number for everybody. For example, shed when a worker is over 85% KV-block occupancy. The #11865 rejects only when every eligible worker is over it. So the pool has exactly two states: open to all, or closed to all. The moment saturation is crossed, a 200-token chat request and a 100k-token request get treated identically: both get a 429. The customers want flexibility here as not all requests are equal under load. The EPP already knows prompt size because it tokenized, and a retry marker is one header away so we can extend this.
-The router side already has most of the machinery: the KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket — that is, bucketed on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length. So request-size-aware classes exist; what's missing is expressing shed thresholds per class rather than process-wide.
+Today the threshold is one number for everybody. For example, shed when a worker is over 85% KV-block occupancy. The #11865 rejects only when every eligible worker is over it. So the pool has exactly two states: open to all, or closed to all. The moment saturation is crossed, a 200-token chat request and a 100k-token request get treated identically: both get a 429. The customers want flexibility here as not all requests are equal under load. 
 
-The classifier itself is reusable — `PolicyProfile::resolve_class_index` is public, not
-scheduler-internal. The complication is its argument: it takes *uncached* tokens, and
-the EPP cannot know those at shed time. Overlap comes from the KV index query inside
-`pick()`, whereas the shed gate runs before the body is even decoded. So this
-requirement resolves into one of three options, which differ in cost and in whether the
+The customer wants to admit small first-attempts while shedding the oversized retries. For example an oversized retry might shed at 70% while a small first attempt keeps being admitted until 95%. So the class is (request size, retry-vs-first-attempt). Dynamo has no concept of the retry marker for a class. In this proposal the EPP would set policy_class = "retry" or "first_attempt".
+We will take the uncached_tokens argument as the proxy for the request size. This is better, since a 100k-token request with a 99k prefix hit is cheap and shouldn't be shed as if it were expensive. The classifier multiplies them, so the pair (size, retry) is the request_class.
+
+Today the shed decision is funtion_of(worker_state). The client wants function_of(worker_state, request_class).
+
+
+The router side already has some of the machinery in the KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket — that is, bucketed on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length.
+But it drives queueing, and the shed path never calls it. They're also in different crates: classification in dynamo-kv-router, shed threshold in dynamo-llm's monitor.
+
+
+The classifier itself is reusable and implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, and the EPP cannot know those at shed time. Overlap comes from the KV index query inside `pick()`, whereas the shed gate runs before the body is even decoded. 
+
+```bash
+pub fn resolve_class_index(&self, requested: Option<&str>, uncached_tokens: usize) -> usize {
+    match &self.classifier {
+        PolicyClassifier::SyntheticSingle { class_index } => *class_index,
+        PolicyClassifier::FamilyBucket(classifier) => {
+            // TODO: Add bounded observability for unknown requested policy values.
+            classifier.class_index(requested, uncached_tokens)
+        }
+    }
+}
+```
+
+So this requirement resolves into one of three options, which differ in cost and in whether the
 router changes at all:
 
 1. **Classify on raw token count in the EPP.** No router change. The EPP keeps its own
@@ -181,9 +198,8 @@ router changes at all:
    `AdmissionDecision` is `Bypass | Ready | Defer` today, with no rejection variant, so
    the policy-class admission API can hold a request indefinitely but cannot shed one.
 
-A related question is where per-class thresholds are configured. They arguably belong
-beside the class definitions in the router's policy YAML — which already carries a
-per-class `admission:` envelope — rather than in EPP environment variables, since
+The per-class thresholds should be configured in the router's policy YAML — which already carries a
+per-class `admission:` envelope rather than in EPP environment variables, since
 splitting class definitions from class thresholds invites drift.
 
 This DEP does not pick one yet; the choice should be made before implementation starts.
@@ -393,7 +409,7 @@ loading in this first cut.
    router's existing class assignment. Satisfies REQ 3.
 6. Document the authoring model and ship one example custom plugin alongside the
    existing GAIE docs.
-   
+
 
 # Related Proposals
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -1,4 +1,4 @@
-# Make the Dynamo Rust EPP Extensible (PrepareData + Load Shedding)
+# Make the Dynamo Rust EPP Extensible (PrepareData + Load Shedding + Worker State)
 
 **Status**: Draft
 
@@ -16,9 +16,13 @@
 
 **Review Date**: [TBD]
 
-**Pull Request**: [TBD — link to this PR in ai-dynamo/enhancements]
+**Pull Request**: [ai-dynamo/enhancements#96](https://github.com/ai-dynamo/enhancements/pull/96)
 
-**Implementation PR / Tracking Issue**: [TBD — link to ai-dynamo/dynamo tracking issue]
+**Implementation PR / Tracking Issue**: [TBD — link to ai-dynamo/dynamo tracking issue].
+Related in-flight work: [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865)
+(built-in load shedding, DEP-1073) and
+[dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868) (response usage on the
+completion hook).
 
 # Summary
 
@@ -29,19 +33,29 @@ follows the GAIE / llm-d pipeline and supports plugins — is being deprecated, 
 the Rust EPP becomes the single EPP and must absorb the extensibility that
 previously only existed in Go.
 
-This proposal adds a minimal, two-hook extension model to the Rust EPP so users
-can supply their own code at exactly two points: **PrepareData** (per-request
-data preparation before scheduling; tokenization is the first use) and **load
-shedding / admission** (reject a request under overload before scheduling).
-Everything else — parsing, the KV-aware scheduler/picker, and bookkeeping —
-stays built in. We deliberately do not reproduce the full llm-d pipeline.
+This proposal adds a minimal extension model to the Rust EPP: **two hooks and one
+shared input**. The hooks are **PrepareData** (per-request data preparation before
+scheduling; tokenization is the first use) and **load shedding / admission** (reject
+a request under overload before scheduling). The shared input is a read-only
+**worker-state view** — the KV and prefill load signal that overload decisions
+actually depend on — exposed once at the extension boundary instead of being
+rebuilt privately by every implementation. Everything else — parsing, the KV-aware
+scheduler/picker, and bookkeeping — stays built in. We deliberately do not reproduce
+the full llm-d pipeline.
+
+The worker-state view is the load-bearing addition. A shedding policy that cannot
+see KV-cache and queue saturation is not a shedding policy, and today no extension
+point can see it: `EndpointPicker::pick` receives request metadata and an endpoint
+list carrying pod identity only, so any out-of-tree policy must stand up a parallel
+state feed. Exposing state as an input is deliberately *not* the same as making
+scoring pluggable, which remains a non-goal.
 
 # Motivation
 
 The Go EPP is being deprecated, and its plugin-based extensibility goes away with
 it. The Rust EPP cannot currently be extended: all logic lives in one router
 implementation, so users who want custom tokenization or custom load-shedding
-policy must fork it. Two concrete needs drive this proposal:
+policy must fork it. Three concrete needs drive this proposal:
 
 - **Tokenization must be swappable.** Different deployments tokenize differently
   (in-process, vLLM `/render`, estimate/byte-packing). llm-d moved tokenized
@@ -53,12 +67,30 @@ policy must fork it. Two concrete needs drive this proposal:
   serving must look at KV-cache and queue saturation, not generic request rate.
   It belongs inside the EPP and users want to supply their own policy. Dynamo's
   frontend already sheds load (HTTP 529); the GAIE path needs the same, made
-  extensible.
+  extensible. The *built-in* half of this is in flight in dynamo#11865, which
+  reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated
+  { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. That
+  makes shedding an explicit, gateway-routable routing signal rather than an
+  implicit shed-by-timeout — but the thresholds are process-wide environment
+  variables and the predicate is fixed. What remains is the seam that lets a
+  deployment supply its own predicate.
+- **Policy state must be shared, not rebuilt.** Every interesting overload or
+  prioritization policy consumes the same family of signals: active decode blocks
+  against `kv_total_blocks`, active prefill tokens against `max_num_batched_tokens`,
+  queue depth. The EPP already computes these. They are not reachable from any
+  extension point, so each out-of-tree policy would have to re-derive them from
+  its own subscription — duplicate plumbing, and a second source of truth that can
+  silently disagree with the one the built-in shedder uses. This is the single
+  most requested item from integrators (REQ 1) and the main change in this
+  revision.
 
 ## Goals
 
 * Provide exactly two extension points in the Rust EPP: PrepareData and load
   shedding / admission.
+* Expose one read-only worker-state view as a first-class input, consumed by the
+  built-in shedder and available to any hook, so policy state has a single source
+  of truth.
 * Move today's inline tokenization behind the default PrepareData hook with no
   behavior change.
 * Ship a default load-shedding hook with parity to the frontend's
@@ -70,27 +102,97 @@ policy must fork it. Two concrete needs drive this proposal:
 
 ### Non Goals
 
-* Pluggable scorers, pickers, or profile handlers. This interface depends on the Dynamo Router and the change has to come with the change in its interfaces. 
+* Pluggable scorers, pickers, or profile handlers. This interface depends on the
+  Dynamo Router and the change has to come with the change in its interfaces.
+  Exposing worker state as a read-only *input* (above) does not breach this: a
+  policy may read the same signals the scheduler reads, and may reject or defer a
+  request, but it does not participate in scoring or selection.
+* Steering the router's internal scoring from an EPP extension — for example
+  zeroing a worker's prefix-overlap credit, retuning the KV indexer's TTL decay, or
+  forcing an index resync for one worker. These are legitimate needs (see REQ 4)
+  but they are operations on the router's own state, not on the EPP's request path,
+  and giving the EPP a back door into them would create exactly the coupling the
+  first non-goal avoids. They belong to the router and its policy-class admission
+  API.
 * DataProducer dependency graphs, fairness / priority-band queues, request
   eviction, or the `flowControl` feature gate from llm-d.
 * Dynamic plugin loading (`.so` / WASM).
 * Any dependency on the deprecated Go EPP or its config schema.
+
+## Requirements
+
+These come from a production integrator running the Rust EPP behind agentgateway,
+who intends to supply their own load-shedding and prioritization policy. Their
+framing is worth recording because it narrows the design: for them load shedding is
+primarily a *routing signal* — a fast explicit rejection that failover can act on,
+replacing implicit shed-by-timeout that wastes prefill compute — and prioritization
+is about retry-versus-first-attempt and request size, not tenant tiers.
+
+### REQ 1 Worker state as a first-class input
+
+Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to the
+extension boundary rather than something each policy derives itself. **Not yet met.**
+`pick()` receives request metadata and an endpoint list of pod identity only; in
+practice the server passes an empty endpoint slice because pickers resolve endpoints
+internally. All load signal is private to the concrete router. This is the gap this
+revision closes.
+
+### REQ 2 Shed semantics distinguishable from failure
+
+Rejection under overload must be distinguishable from an error and routable by the
+gateway, with a retry hint. **Met by dynamo#11865** via `PickError::Saturated
+{ retry_after_secs }` → HTTP 429 with `Retry-After`. Because it is an ordinary error
+variant, an out-of-tree policy can return it too.
+
+### REQ 3 Response usage on the completion hook
+
+The terminal response's token usage — at minimum
+`usage.prompt_tokens_details.cached_tokens` — must reach the picker so a deployment
+can compare predicted prefix overlap against the observed cache hit. **Met by
+dynamo#11868**, which adds `on_request_complete_with_usage`. Note this is a
+per-request feedback input, not telemetry: the `dynamo_epp_cached_tokens` histogram
+added alongside it is labelled by model only and cannot be joined to an individual
+pick decision.
+
+### REQ 4 Closed-loop calibration of the predictor
+
+Sustained disagreement between predicted overlap and reported `cached_tokens` should
+be able to act on the predictor: retune decay parameters where routing is
+approximate, and demote or resync a diverged worker where it is event-driven.
+**Out of scope for this DEP**, and worth being explicit about why. The actions are
+operations on router state, unreachable from `EndpointPicker` — an extension can
+wrap the picker but cannot change how the picker scores. Recording the error ledger
+is already possible with REQ 3; acting on it is router work. Note also that the EPP
+has no approximate-routing mode today, so the parameter-adaptation half of this
+requirement has no surface to act on.
+
+### REQ 5 Class-aware shed thresholds
+
+A uniform threshold turns "nearly full" into "closed for everyone at once," which is
+when retry amplification starts. Shedding should be able to distinguish request
+classes — keeping small first attempts flowing while shedding oversized retries,
+which are the cheapest to redirect. **Not met in the EPP.** The EPP already knows
+prompt size because it tokenized, and a retry marker is one header away. The router
+side already has most of the machinery; see the division of labor below.
 
 # Proposal
 
 ## Overview
 
 Keep the existing request flow and insert two hook points around the existing
-scheduler:
+scheduler, both reading one shared worker-state view:
 
 ```
-ext_proc request
+                                        worker-state view (read-only, shared)
+                                            |            |
+ext_proc request                            v            v
   -> parse body / build request        (built in)
   -> PrepareData hook                   (pluggable)  <-- tokenization lives here
   -> Load-shedding / admission hook     (pluggable)  <-- reject under overload
   -> Scheduler: pick worker             (built in, existing KV router)
   -> attach routing headers / tokens    (built in)
   -> return decision to Envoy
+  -> response hooks                     (built in)  <-- prefill complete, usage
 ```
 
 This mirrors the useful part of the llm-d / GAIE flow (PrepareData, then
@@ -112,12 +214,14 @@ Parse body → Build LLMRequest → Admission (flow control)
 | Parse body / build request | No | Stable, shared parsing |
 | PrepareData (tokenization) | Yes | Users need different tokenizers; enables prefix-cache routing and tokens-in forwarding |
 | Load shedding (admission) | Yes | Users need their own overload policy |
+| Worker-state view | No — read-only input | Not a stage. One shared source of truth for the signals policies need (REQ 1) |
 | Scheduler (worker pick) | No (for now) | The existing KV-aware router stays the default; can be revisited later |
 | Bookkeeping / headers | No | Internal correctness |
 
 The Rust EPP is currently `ext_proc` + scheduler; this proposal adds exactly two
-pluggable stages in front of the scheduler and leaves the scheduler built in. We
-are not making parsing, scoring, or picking pluggable at this time.
+pluggable stages in front of the scheduler, one read-only input feeding them, and
+leaves the scheduler built in. We are not making parsing, scoring, or picking
+pluggable at this time.
 
 ## How the hooks work (conceptually)
 
@@ -134,6 +238,74 @@ are not making parsing, scoring, or picking pluggable at this time.
 * The scheduler then runs unchanged, consuming the token data that PrepareData
   produced.
 * We should also reconsider how to do priority scheduling to decide if we want to align with GAIE. See related [proposal](https://github.com/ai-dynamo/enhancements/pull/90/changes)
+
+## Worker state as a first-class input
+
+A load-shedding hook is only as good as what it can see. Today the EPP computes the
+overload signal in `KvWorkerMonitor` and keeps it private to the concrete router, so
+a hook would either be handed a pre-baked boolean or have to build its own feed. The
+first is not a policy seam; the second duplicates plumbing and creates a second
+source of truth that can disagree with the built-in shedder.
+
+Instead, the same state the built-in shedder consumes is exposed once, read-only, at
+the extension boundary:
+
+* **Per-worker load**, in the terms the thresholds are already expressed in: active
+  decode blocks against `kv_total_blocks`, active prefill tokens against
+  `max_num_batched_tokens`, and queue depth.
+* **The derived overloaded-worker set**, so a policy can ask the cheap question
+  ("is anything free?") without recomputing the expensive one.
+* **A distinction between structurally eligible and currently available workers**,
+  matching the split the router's admission contract already makes, so a policy can
+  tell "no worker can ever serve this" from "every worker is busy right now."
+
+Three properties keep this from turning into a scoring API. The view is **read-only**:
+a policy observes, it does not mutate router state. It is a **snapshot** with a
+consistent view across a single decision, not a live handle that invites a policy to
+poll in a loop. And it is **typed and narrow** — named accessors for signals we
+already maintain, not a metadata bag — so adding a fact is a deliberate act and the
+boundary stays reviewable.
+
+This is what makes the decorator authoring model honest. Wrapping the stock router
+in an outer policy already works mechanically — the trait is a normal Rust trait and
+the server is generic over it — but a wrapper that cannot see load can only reject
+blindly or reorder what comes back. With the state view it can make the same class
+of decision the built-in shedder makes, which is the whole point of the seam.
+
+## Relationship to the router's policy-class admission API
+
+Dynamo already has a second extension boundary that is easy to miss and must not be
+duplicated: `PolicyClassAdmissionPolicy`, in
+`lib/kv-router/src/scheduling/queue_admission/`. It is contract-complete — per-class
+lifecycle events, an opaque per-class configuration envelope each policy
+deserializes itself, and crucially a `Defer` / `MakeReady` pair, so it can *hold* a
+request rather than only rejecting it. It has no production implementations today
+and is not wired into the EPP.
+
+The two boundaries answer different questions and should stay that way:
+
+| | EPP hooks (this DEP) | Router policy-class admission |
+|---|---|---|
+| Scope | One request at the gateway edge | A class of requests inside the scheduler |
+| Vocabulary | Admit or reject, now | Admit, defer, release, place |
+| Signal | Worker state at pick time | Queue state and class capacity over time |
+| Answer to overload | Shed with 429 + `Retry-After` | Queue and release when capacity returns |
+
+Shedding at the edge and queueing in the scheduler are complements: the edge is where
+you cheaply refuse work you should never start, and the scheduler is where you hold
+work that is worth waiting for. Building a third mechanism to span them would be a
+mistake.
+
+This division also gives REQ 5 its natural home. Policy classes are already assigned
+either by explicit class name or by a `(policy family, uncached-ISL bucket)` pair —
+that is, **request-size-aware classes already exist** in the router, which is most of
+what class-aware shedding asks for. The remaining work is connective rather than new
+machinery: the EPP knows prompt size and can see a retry marker, so it can label a
+request with a policy class, and shed thresholds can then be expressed per class
+instead of process-wide. Whether that label rides the existing `policy_class` hint
+(the frontend takes a `policy-class` metadata key; the selection service takes an
+`x-dynamo-meta-policy-class` header) or a dedicated EPP-side mapping is an
+implementation question this DEP defers.
 
 ## Configuration
 
@@ -154,12 +326,38 @@ loading in this first cut.
 
 ## Delivery outline
 
-1. Introduce the two hook points in the Rust EPP and move today's inline
-   tokenization behind the default PrepareData hook (no behavior change).
-2. Add a default load-shedding hook (saturation / busy-threshold parity with the
-   frontend) and the config plumbing to select / chain hooks.
-3. Document the authoring model and ship one example custom hook alongside the
+1. Land the built-in shedder (dynamo#11865): `KvWorkerMonitor` reuse,
+   `PickError::Saturated { retry_after_secs }`, HTTP 429 with `Retry-After`.
+   Satisfies REQ 2 and gives the later hook a reference implementation.
+2. Expose the worker-state view as a read-only input and refactor the built-in
+   shedder to consume it, proving the boundary carries a real policy before any
+   third party depends on it. Satisfies REQ 1.
+3. Introduce the two hook points and move today's inline tokenization behind the
+   default PrepareData hook (no behavior change).
+4. Add the config plumbing to select / chain hooks, with the built-in shedder as
+   the default load-shedding hook.
+5. Express shed thresholds per policy class rather than process-wide, reusing the
+   router's existing class assignment. Satisfies REQ 5.
+6. Document the authoring model and ship one example custom hook alongside the
    existing GAIE docs.
+
+Step 2 before step 3 is deliberate. Shipping hooks first would mean publishing a
+seam whose only real policy input is still private, which is how a boundary ends up
+frozen around the wrong shape.
+
+# Related Proposals
+
+* [DEP: Multi-DC KV-Aware Request Routing](https://github.com/ai-dynamo/dynamo/issues/11225) —
+  its Relay publishes the same family of worker/serving signals upward for the
+  fleet-level loop. One worker-state surface should feed both the Relay and the
+  EPP's policies rather than two parallel paths.
+* [Priority scheduling proposal](https://github.com/ai-dynamo/enhancements/pull/90) —
+  decides whether EPP-side prioritization aligns with GAIE; REQ 5 depends on the
+  outcome.
+* [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865) — built-in load
+  shedding (REQ 2).
+* [dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868) — response usage on
+  the completion hook (REQ 3).
 
 # Alternate Solutions
 
@@ -179,9 +377,9 @@ loading in this first cut.
 
 **Reason Rejected:**
 
-* Over-engineered for current needs. The two hooks cover the real use cases
-  (custom tokenizer, custom overload policy). Additional extension points can be
-  proposed later if a concrete need appears.
+* Over-engineered for current needs. The two hooks plus the shared state view cover
+  the real use cases (custom tokenizer, custom overload policy). Additional
+  extension points can be proposed later if a concrete need appears.
 
 ## Alt 2 Keep load shedding / tokenization out of the EPP (gateway-level only)
 
@@ -199,3 +397,32 @@ loading in this first cut.
 
 * Both capabilities are inherently LLM-aware and belong in the EPP, consistent
   with llm-d and Dynamo's own frontend admission behavior.
+
+## Alt 3 Ship the hooks without exposing worker state
+
+Leave the state feed private and let each out-of-tree policy build its own — the
+`EndpointPicker` trait is already wrappable, so an integrator can decorate the stock
+router and subscribe to worker events independently.
+
+**Pros:**
+
+* Smallest possible boundary; no new types to maintain or version.
+* Nothing to get wrong in the state view's shape before we have several policies to
+  generalize from.
+
+**Cons:**
+
+* Two sources of truth for overload. A policy's private feed and the built-in
+  shedder's `KvWorkerMonitor` can disagree, and the resulting behavior — shed by one,
+  admitted by the other — is very hard to debug from outside.
+* Duplicate plumbing in every deployment that wants a custom policy, which is the
+  specific cost REQ 1 was raised to avoid.
+* The hook seam would be mostly decorative: a shedding hook that cannot see
+  saturation can only apply request-shaped heuristics, so the interesting policies
+  would still live in forks.
+
+**Reason Rejected:**
+
+* This is effectively the status quo with extra ceremony. If the seam ships without
+  the input the policy needs, integrators keep forking and we still own the
+  compatibility burden of a published trait.

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -1,4 +1,4 @@
-# Make the Dynamo Rust EPP Extensible (PrepareData + Load Shedding + Worker State)
+# Make the Dynamo Rust EPP Extensible through Plugins
 
 **Status**: Draft
 
@@ -28,28 +28,23 @@ EPP response (DYNO-93).
 # Summary
 
 The Dynamo Rust EPP (`dynamo-ext-proc`) today is effectively two things: the
-Envoy `ext_proc` server and a single, hard-wired router that tokenizes the
+Envoy `ext_proc` server and a hard-wired router that tokenizes the
 prompt and picks a worker. There are no extension points. The Go EPP — which
 follows the GAIE / llm-d pipeline and supports plugins — is being deprecated, so
 the Rust EPP becomes the single EPP and must absorb the extensibility that
 previously only existed in Go.
 
-This proposal adds a minimal extension model to the Rust EPP: **two plugin points and
+This proposal adds a minimal extension model to the Rust EPP: **two plugin types and
 one shared input**. The plugins are **DataProducer** (per-request data preparation before
-scheduling; tokenization is the first use) and ** Admitter (load shedding) ** (reject
+scheduling; tokenization is the first use) and **Admitter (load shedding)** (reject
 a request under overload before scheduling). 
 
-The shared input is a read-only
-**worker-state view** — the KV and prefill load signal that overload decisions
-actually depend on — exposed once at the extension boundary. Everything else — parsing, the KV-aware
-scheduler/picker, and bookkeeping — stays built in. We deliberately do not reproduce
-the full llm-d pipeline.
-
+All plugins will need to have read-only worker-state view (the KV and prefill load signal)
 The worker-state view is a critical addition. A shedding policy that cannot
 see KV-cache and prefill saturation is not a shedding policy, and today no extension
 point can see it: `EndpointPicker::pick` receives request metadata and an endpoint
 list carrying pod identity only, so any out-of-tree policy must stand up a parallel
-state feed. Exposing state as an input is deliberately *not* the same as making
+state feed. Exposing state as an input is deliberately not the same as making
 scoring pluggable, which remains a non-goal.
 
 # Motivation
@@ -70,33 +65,57 @@ policy must fork it. Three concrete needs drive this proposal:
   It belongs inside the EPP and users want to supply their own policy. Dynamo's
   frontend already sheds load (HTTP 529); the GAIE path needs the same, made
   extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers pressing on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity.
-  The *built-in* half of this is in
-  [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which
-  reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated
+  The beginning of its implementation is in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated
   { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry
-  over: `POST`/`GET /busy_threshold` retunes thresholds per model on a live fleet,
+  over: `POST`/`GET /busy_threshold` returns thresholds per model on a live fleet,
   whereas the EPP reads env vars once at startup. Closing that is out of scope here but needs to be done.
-- **Policy state must be shared.** Every prioritization policy consumes the same family of signals: active decode blocks and KV used blocks against `kv_total_blocks`, and active prefill tokens against
-  `max_num_batched_tokens`. The EPP already tracks these in `WorkerLoadState`. They
-  are not reachable from any extension point, so each out-of-tree policy would have
-  to re-derive them from its own subscription. We want to avoid duplicate plumbing, and a second
-  source of truth that can silently disagree with the one the built-in shedder uses.
-  This leads to (REQ 1).
+- **Policy state** must be shared, not rebuilt. Any policy reasoning about saturation needs the signals the built-in thresholds are already expressed in: active_decode_blocks and kv_used_blocks against kv_total_blocks, and active_prefill_tokens against max_num_batched_tokens. These span two feeds — numerators from the ActiveLoad stream, denominators from the runtime-config watch — and WorkerLoadState already joins them. It lives in dynamo-llm, which the EPP links today, so the EPP should construct a KvWorkerMonitor and reuse it rather than grow a parallel implementation. Tracking is only half the gap: the state is a private field and EndpointPicker::pick has no parameter. We need to expose it to enable plugins:
+
+```bash
+async fn pick(
+    &self,
+    req: &RequestInfo,
+    endpoints: &[Endpoint], 
+    load: &WorkerLoadView, // here
+) -> Result<PickResult, PickError>;
+
+pub struct WorkerLoadView{}
+  load: FxHashMap<WorkerWithDpRank, WorkerLoad>
+  overloaded: FxHashSet<WorkerId>,
+  /// Thresholds in force when the snapshot was taken.
+  thresholds: LoadThresholdConfig,
+  observed_at: Instant,
+}
+
+pub struct WorkerLoadState {
+    pub active_decode_blocks: HashMap<u32, u64>,
+    pub kv_used_blocks: HashMap<u32, u64>,
+    pub kv_total_blocks: HashMap<u32, u64>,
+    pub active_prefill_tokens: HashMap<u32, u64>,
+    /// max_num_batched_tokens from runtime config (same for all dp_ranks)
+    pub max_num_batched_tokens: HashMap<u32, u64>,
+    decode_overload_latches: HashMap<u32, DecodeOverloadLatchState>,
+}
+```
+  
 
 ## Goals
+
 
 * Provide extension points in the Rust EPP: DataProducer and Admitter.
 * Expose one read-only worker-state view as a first-class input available to any plugin, so policy state has a single source of truth.
 * Move today's inline tokenization behind the default PrepareData plugin with no
   behavior change.
 * Ship a default load-shedding plugin that reuses the frontend's saturation /
-  busy-threshold *detection* — the same `KvWorkerMonitor`, thresholds, and
-  overloaded-worker exclusion — while deliberately diverging on the decision surface:
+  busy-threshold detection (the same `KvWorkerMonitor`, thresholds, and
+  overloaded-worker exclusion) while deliberately diverging on the decision surface:
   an explicit pre-tokenization gate rather than a routing failure surfaced as an
   error, and HTTP 429 with `Retry-After` rather than 529. Full parity is not the
   goal; a shared detector with a gateway-appropriate contract is.
 * Allow users to add plugins via compile-time registration in a custom Rust EPP
   binary/image.
+* We deliberately do not reproduce the full llm-d pipeline.
+
 
 ### Non Goals
 
@@ -118,16 +137,14 @@ policy must fork it. Three concrete needs drive this proposal:
 
 ## Requirements
 
-These come from clients who intend to supply their own load-shedding and prioritization policy. Their
-framing is worth recording because it narrows the design: for them load shedding is
+Clients want to supply their own load-shedding and prioritization policy. For them load shedding is
 primarily a *routing signal* — a fast explicit rejection that failover can act on,
-replacing implicit shed-by-timeout that wastes prefill compute — and prioritization
+replacing implicit shed-by-timeout that wastes prefill compute . Also for them prioritization
 is about retry-versus-first-attempt and request size, not tenant tiers.
 
 ### REQ 1 Worker state as a first-class input
 
-Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to plugins rather than something each policy derives itself. Note that of these, KV blocks and prefill tokens are tracked today; queue depth is not, and this DEP proposes exposing what exists rather than adding a
-new signal. 
+Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to plugins rather than something each policy derives itself. Note that of these, KV blocks and prefill tokens are tracked today; queue depth is not, and this DEP proposes exposing in. 
 
 
 ### REQ 2 Shed semantics distinguishable from failure
@@ -304,7 +321,7 @@ REQ 2: only the second case should become 429 with `Retry-After`. The first is a
 permanent failure, and attaching a retry hint to it actively misleads the gateway's
 failover logic. A policy that cannot see both sets cannot tell the two apart.
 
-### What keeps this from becoming a scoring API which we do not want to chage
+### What keeps this from becoming a scoring API which we do not want to change
 
 Exposing state is not the same as making selection pluggable, which stays a Non Goal.
 Three properties hold that line:
@@ -346,7 +363,7 @@ mistake.
 
 The Rust EPP gets a small, self-contained config (a mounted file / env var read
 at startup) with just two things: which PrepareData plugin to use, and an ordered
-list of load-shedding plugins to run. No CRD and no dependenc. 
+list of load-shedding plugins to run. No CRD and no dependency. 
 Built-in plugins (a default tokenizer and a default
 saturation / busy-threshold shedder) are always available; users select their own
 by name. Sensible defaults mean an unconfigured Rust EPP behaves as it does
@@ -376,10 +393,7 @@ loading in this first cut.
    router's existing class assignment. Satisfies REQ 3.
 6. Document the authoring model and ship one example custom plugin alongside the
    existing GAIE docs.
-
-Step 2 before step 3 is deliberate. Shipping plugins first would mean publishing a
-seam whose only real policy input is still private, which is how a boundary ends up
-frozen around the wrong shape.
+   
 
 # Related Proposals
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -272,28 +272,25 @@ cheap fix is for the monitor to publish an immutable snapshot into a `watch` cha
 a pattern it already uses internally — so the update path pays the cost and each
 decision takes one refcount bump rather than a map traversal.
 
-For the Admitter the following data is needed. Upstream needs the same class of input:
-llm-d's only shipping admitter, `latency-slo-admitter`, reads `KVCacheUsagePercent`
-from endpoint metrics and `DispatchedRequestCount` from endpoint attributes, and admits
-a sheddable request when any endpoint is idle or cold. Same question, same kind of
-per-endpoint load data.
+For the Admitter the following data is needed. 
 
 **1. Raw per-worker load.** The same numbers the built-in thresholds compare against,
 per worker and per dp_rank: `active_decode_blocks` and `kv_used_blocks` against
 `kv_total_blocks`, and `active_prefill_tokens` against `max_num_batched_tokens`. A
-plugin that wants a different rule — shed at 70% instead of 85%, or weigh prefill
-pressure differently — reads these and decides for itself. Queue depth is
-deliberately absent: nothing tracks a per-worker pending count today, so adding it
-would be a separate change rather than something to assume is available.
+plugin that wants a different rule (i.e. shed at 70% instead of 85%, or weigh prefill
+pressure differently) reads these  numbers so that it can decide for itself. 
 
-**2. The precomputed overloaded-worker set.** Which workers are currently too busy. A
+**2. We need to add the Queue depth to the worker state view.
+Workers already publish per-worker, per-dp_rank queued request counts and token sums in the forward-pass metrics stream, but that stream does not feed the router. A solution is needed here.
+
+**3. The precomputed overloaded-worker set.** Which workers are currently too busy. A
 plugin uses this to decide whether to admit the request. If some workers are free, it
 admits and lets normal routing pick one. If they are all busy, the plugin decides what
 to do with *this* request — for example reject low-priority traffic with 429 and
 `Retry-After` but let high-priority traffic through. That per-request choice is the
 point, since the built-in shedder is all-or-nothing.
 
-**3. Structurally eligible versus currently available workers.** Two sets, matching
+**4. Structurally eligible versus currently available workers.** Two sets, matching
 the split `WorkerEligibilitySnapshot` already makes in the router's admission
 contract:
 
@@ -349,8 +346,8 @@ mistake.
 
 The Rust EPP gets a small, self-contained config (a mounted file / env var read
 at startup) with just two things: which PrepareData plugin to use, and an ordered
-list of load-shedding plugins to run. No CRD and no dependency on the Go EPP's
-config schema. Built-in plugins (a default tokenizer and a default
+list of load-shedding plugins to run. No CRD and no dependenc. 
+Built-in plugins (a default tokenizer and a default
 saturation / busy-threshold shedder) are always available; users select their own
 by name. Sensible defaults mean an unconfigured Rust EPP behaves as it does
 today.

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -499,78 +499,7 @@ lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 
 # Alternate Solutions
 
-## Alt 1 Reproduce the full llm-d / GAIE plugin pipeline in Rust
-
-**Pros:**
-
-* Maximum flexibility (pluggable scorers, pickers, profile handlers, fairness,
-  flow control).
-* Closer 1:1 mapping to the Go EPP and upstream GAIE.
-
-**Cons:**
-
-* Large surface area and ongoing maintenance for extension points nobody is
-  asking for yet.
-* Slower to deliver the two capabilities actually needed.
-
-**Reason Rejected:**
-
-* Over-engineered for current needs. The two plugins plus the shared state view cover
-  the real use cases (custom tokenizer, custom overload policy). Additional
-  extension points can be proposed later if a concrete need appears.
-* The gap is also narrower than it looks. `DataProducer` and `Admitter` are the only
-  two plugin points llm-d places between request parsing and scheduling, so this
-  proposal already matches upstream over that span. What Alt 1 adds beyond it is the
-  flow-control machinery and pluggable scoring — both already Non Goals, and the
-  former not pluggable upstream either.
-
-## Alt 2 Keep load shedding / tokenization out of the EPP (gateway-level only)
-
-**Pros:**
-
-* No EPP changes.
-
-**Cons:**
-
-* Generic gateway RPS limits are a poor proxy for KV-cache / queue saturation.
-* Tokenization for prefix-cache routing has to happen where routing decisions are
-  made.
-
-**Reason Rejected:**
-
-* Both capabilities are inherently LLM-aware and belong in the EPP, consistent
-  with llm-d and Dynamo's own frontend admission behavior.
-
-## Alt 3 Ship the plugins without exposing worker state
-
-Leave the state feed private and let each out-of-tree policy build its own — the
-`EndpointPicker` trait is already wrappable, so an integrator can decorate the stock
-router and subscribe to worker events independently.
-
-**Pros:**
-
-* Smallest possible boundary; no new types to maintain or version.
-* Nothing to get wrong in the state view's shape before we have several policies to
-  generalize from.
-
-**Cons:**
-
-* Two sources of truth for overload. A policy's private feed and the built-in
-  shedder's `KvWorkerMonitor` can disagree, and the resulting behavior — shed by one,
-  admitted by the other — is very hard to debug from outside.
-* Duplicate plumbing in every deployment that wants a custom policy, which is the
-  specific cost REQ 1 was raised to avoid.
-* The plugin seam would be mostly decorative: a shedding plugin that cannot see
-  saturation can only apply request-shaped heuristics, so the interesting policies
-  would still live in forks.
-
-**Reason Rejected:**
-
-* This is effectively the status quo with extra ceremony. If the seam ships without
-  the input the policy needs, integrators keep forking and we still own the
-  compatibility burden of a published trait.
-
-## Alt 4 Implement class-aware shedding in the KV router; make the EPP a thin wrapper
+## Alt 1 Implement class-aware shedding in the KV router; make the EPP a thin wrapper
 
 Put the shed decision where classification already happens — inside `dynamo-kv-router`'s
 scheduling path — instead of adding an Admitter plugin at the gateway. The EPP then
@@ -642,3 +571,76 @@ designed and unbuilt, and its decision set is `Bypass` / `Ready` / `Defer` with 
 `Reject`. Alt 4 amounts to adding `Reject` to that contract, so it likely belongs folded
 into whichever proposal owns it rather than pursued from the EPP side. Identify that
 owner before choosing between Alt 4 and the main proposal.
+
+
+## Alt 2 Reproduce the full llm-d / GAIE plugin pipeline in Rust
+
+**Pros:**
+
+* Maximum flexibility (pluggable scorers, pickers, profile handlers, fairness,
+  flow control).
+* Closer 1:1 mapping to the Go EPP and upstream GAIE.
+
+**Cons:**
+
+* Large surface area and ongoing maintenance for extension points nobody is
+  asking for yet.
+* Slower to deliver the two capabilities actually needed.
+
+**Reason Rejected:**
+
+* Over-engineered for current needs. The two plugins plus the shared state view cover
+  the real use cases (custom tokenizer, custom overload policy). Additional
+  extension points can be proposed later if a concrete need appears.
+* The gap is also narrower than it looks. `DataProducer` and `Admitter` are the only
+  two plugin points llm-d places between request parsing and scheduling, so this
+  proposal already matches upstream over that span. What Alt 1 adds beyond it is the
+  flow-control machinery and pluggable scoring — both already Non Goals, and the
+  former not pluggable upstream either.
+
+## Alt 3 Keep load shedding / tokenization out of the EPP (gateway-level only)
+
+**Pros:**
+
+* No EPP changes.
+
+**Cons:**
+
+* Generic gateway RPS limits are a poor proxy for KV-cache / queue saturation.
+* Tokenization for prefix-cache routing has to happen where routing decisions are
+  made.
+
+**Reason Rejected:**
+
+* Both capabilities are inherently LLM-aware and belong in the EPP, consistent
+  with llm-d and Dynamo's own frontend admission behavior.
+
+## Alt 4 Ship the plugins without exposing worker state
+
+Leave the state feed private and let each out-of-tree policy build its own — the
+`EndpointPicker` trait is already wrappable, so an integrator can decorate the stock
+router and subscribe to worker events independently.
+
+**Pros:**
+
+* Smallest possible boundary; no new types to maintain or version.
+* Nothing to get wrong in the state view's shape before we have several policies to
+  generalize from.
+
+**Cons:**
+
+* Two sources of truth for overload. A policy's private feed and the built-in
+  shedder's `KvWorkerMonitor` can disagree, and the resulting behavior — shed by one,
+  admitted by the other — is very hard to debug from outside.
+* Duplicate plumbing in every deployment that wants a custom policy, which is the
+  specific cost REQ 1 was raised to avoid.
+* The plugin seam would be mostly decorative: a shedding plugin that cannot see
+  saturation can only apply request-shaped heuristics, so the interesting policies
+  would still live in forks.
+
+**Reason Rejected:**
+
+* This is effectively the status quo with extra ceremony. If the seam ships without
+  the input the policy needs, integrators keep forking and we still own the
+  compatibility burden of a published trait.
+

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -19,10 +19,11 @@
 **Pull Request**: [ai-dynamo/enhancements#96](https://github.com/ai-dynamo/enhancements/pull/96)
 
 **Implementation PR / Tracking Issue**: [TBD — link to ai-dynamo/dynamo tracking issue].
-Related in-flight work: [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865)
-(built-in load shedding, DEP-1073) and
-[dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868) (response usage on the
-completion hook).
+Related in-flight work:
+[dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865) — built-in load
+shedding (DEP-1073), and
+[dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868) — cached_tokens in the
+EPP response (DYNO-93).
 
 # Summary
 
@@ -44,7 +45,7 @@ scheduler/picker, and bookkeeping — stays built in. We deliberately do not rep
 the full llm-d pipeline.
 
 The worker-state view is the load-bearing addition. A shedding policy that cannot
-see KV-cache and queue saturation is not a shedding policy, and today no extension
+see KV-cache and prefill saturation is not a shedding policy, and today no extension
 point can see it: `EndpointPicker::pick` receives request metadata and an endpoint
 list carrying pod identity only, so any out-of-tree policy must stand up a parallel
 state feed. Exposing state as an input is deliberately *not* the same as making
@@ -67,7 +68,8 @@ policy must fork it. Three concrete needs drive this proposal:
   serving must look at KV-cache and queue saturation, not generic request rate.
   It belongs inside the EPP and users want to supply their own policy. Dynamo's
   frontend already sheds load (HTTP 529); the GAIE path needs the same, made
-  extensible. The *built-in* half of this is in flight in dynamo#11865, which
+  extensible. The *built-in* half of this is in flight in
+  [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which
   reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated
   { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. That
   makes shedding an explicit, gateway-routable routing signal rather than an
@@ -76,13 +78,16 @@ policy must fork it. Three concrete needs drive this proposal:
   deployment supply its own predicate.
 - **Policy state must be shared, not rebuilt.** Every interesting overload or
   prioritization policy consumes the same family of signals: active decode blocks
-  against `kv_total_blocks`, active prefill tokens against `max_num_batched_tokens`,
-  queue depth. The EPP already computes these. They are not reachable from any
-  extension point, so each out-of-tree policy would have to re-derive them from
-  its own subscription — duplicate plumbing, and a second source of truth that can
-  silently disagree with the one the built-in shedder uses. This is the single
-  most requested item from integrators (REQ 1) and the main change in this
-  revision.
+  and KV used blocks against `kv_total_blocks`, and active prefill tokens against
+  `max_num_batched_tokens`. The EPP already tracks these in `WorkerLoadState`. They
+  are not reachable from any extension point, so each out-of-tree policy would have
+  to re-derive them from its own subscription — duplicate plumbing, and a second
+  source of truth that can silently disagree with the one the built-in shedder uses.
+  The disagreement is not hypothetical: decode overload is *latched*, clearing only
+  once both the active-blocks and kv-used-blocks signals fall back under threshold,
+  so a reimplementation fed identical raw metrics but lacking the latch will flap
+  where the built-in shedder holds steady. This is the single most requested item
+  from integrators (REQ 1) and the main change in this revision.
 
 ## Goals
 
@@ -130,8 +135,11 @@ is about retry-versus-first-attempt and request size, not tenant tiers.
 
 ### REQ 1 Worker state as a first-class input
 
-Worker state feeds (KV blocks, prefill tokens, queue depth) must be an input to the
-extension boundary rather than something each policy derives itself. **Not yet met.**
+Worker state feeds (as the integrator framed it: KV blocks, prefill tokens, queue
+depth) must be an input to the extension boundary rather than something each policy
+derives itself. Note that of these, KV blocks and prefill tokens are tracked today;
+queue depth is not, and this DEP proposes exposing what exists rather than adding a
+new signal. **Not yet met.**
 `pick()` receives request metadata and an endpoint list of pod identity only; in
 practice the server passes an empty endpoint slice because pickers resolve endpoints
 internally. All load signal is private to the concrete router. This is the gap this
@@ -140,7 +148,8 @@ revision closes.
 ### REQ 2 Shed semantics distinguishable from failure
 
 Rejection under overload must be distinguishable from an error and routable by the
-gateway, with a retry hint. **Met by dynamo#11865** via `PickError::Saturated
+gateway, with a retry hint. **Met by
+[dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865)** via `PickError::Saturated
 { retry_after_secs }` → HTTP 429 with `Retry-After`. Because it is an ordinary error
 variant, an out-of-tree policy can return it too.
 
@@ -149,7 +158,9 @@ variant, an out-of-tree policy can return it too.
 The terminal response's token usage — at minimum
 `usage.prompt_tokens_details.cached_tokens` — must reach the picker so a deployment
 can compare predicted prefix overlap against the observed cache hit. **Met by
-dynamo#11868**, which adds `on_request_complete_with_usage`. Note this is a
+[dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868)** ("Enable
+cached_tokens in EPP response", DYNO-93), which adds
+`on_request_complete_with_usage`. Note this is a
 per-request feedback input, not telemetry: the `dynamo_epp_cached_tokens` histogram
 added alongside it is labelled by model only and cannot be joined to an individual
 pick decision.
@@ -237,7 +248,7 @@ pluggable at this time.
   stops the request.
 * The scheduler then runs unchanged, consuming the token data that PrepareData
   produced.
-* We should also reconsider how to do priority scheduling to decide if we want to align with GAIE. See related [proposal](https://github.com/ai-dynamo/enhancements/pull/90/changes)
+* We should also reconsider how to do priority scheduling to decide if we want to align with GAIE. See related [proposal](https://github.com/ai-dynamo/enhancements/pull/90)
 
 ## Worker state as a first-class input
 
@@ -251,10 +262,14 @@ Instead, the same state the built-in shedder consumes is exposed once, read-only
 the extension boundary:
 
 * **Per-worker load**, in the terms the thresholds are already expressed in: active
-  decode blocks against `kv_total_blocks`, active prefill tokens against
-  `max_num_batched_tokens`, and queue depth.
+  decode blocks and KV used blocks against `kv_total_blocks`, and active prefill
+  tokens against `max_num_batched_tokens`, per dp_rank. Queue depth is *not* part of
+  this set today; adding it would be a deliberate extension of the view, not an
+  assumed member of it.
 * **The derived overloaded-worker set**, so a policy can ask the cheap question
-  ("is anything free?") without recomputing the expensive one.
+  ("is anything free?") without recomputing the expensive one — and, more
+  importantly, get the same latched answer the built-in shedder acts on rather than
+  an unlatched approximation of it.
 * **A distinction between structurally eligible and currently available workers**,
   matching the split the router's admission contract already makes, so a policy can
   tell "no worker can ever serve this" from "every worker is busy right now."
@@ -326,7 +341,8 @@ loading in this first cut.
 
 ## Delivery outline
 
-1. Land the built-in shedder (dynamo#11865): `KvWorkerMonitor` reuse,
+1. Land the built-in shedder
+   ([dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865)): `KvWorkerMonitor` reuse,
    `PickError::Saturated { retry_after_secs }`, HTTP 429 with `Retry-After`.
    Satisfies REQ 2 and gives the later hook a reference implementation.
 2. Expose the worker-state view as a read-only input and refactor the built-in
@@ -354,10 +370,21 @@ frozen around the wrong shape.
 * [Priority scheduling proposal](https://github.com/ai-dynamo/enhancements/pull/90) —
   decides whether EPP-side prioritization aligns with GAIE; REQ 5 depends on the
   outcome.
-* [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865) — built-in load
-  shedding (REQ 2).
-* [dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868) — response usage on
-  the completion hook (REQ 3).
+* [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865) — "Enable load
+  shedding in the EPP" (DEP-1073). Adds the built-in shedder this DEP's default hook
+  is built from: `KvWorkerMonitor` reuse, `PickError::Saturated { retry_after_secs }`,
+  and HTTP 429 with `Retry-After`. Satisfies REQ 2, and its private
+  `WorkerLoadState` is exactly what REQ 1 proposes to expose.
+* [dynamo#11868](https://github.com/ai-dynamo/dynamo/pull/11868) — "Enable
+  cached_tokens in EPP response" (DYNO-93). Parses `usage` from the response body and
+  adds `on_request_complete_with_usage`, giving a policy the observed cache hit to
+  compare against its predicted overlap. Satisfies REQ 3 and is the precondition for
+  the error ledger described in REQ 4.
+
+The two are complements, not overlaps: #11865 reads worker capacity on the request
+path to decide whether to admit, and #11868 reads request outcome on the response
+path after the decision is already made. They do touch the same files, so whichever
+lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 
 # Alternate Solutions
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -200,12 +200,46 @@ This mirrors the useful part of the llm-d / GAIE flow (PrepareData, then
 admission, then scheduling) without the surrounding machinery.
 
 ```
-Parse body → Build LLMRequest → Admission (flow control)
-    → PrepareData plugins  ← tokenization runs here
-    → Admission plugins
+Parse body → Build LLMRequest → Admission (flow control)   ← builtin, not pluggable
+    → DataProducer plugins   ← tokenization runs here
+    → Admitter plugins       ← can reject
     → Scheduler (Filter → Score → Pick)
     → PreRequest plugins → route to model server
 ```
+
+### Alignment with llm-d's two admission layers
+
+llm-d admits in two distinct places. The distinction is easy to miss because both
+are called "admission", and it is worth naming here because it is what makes this
+DEP's single shedding seam a deliberate choice rather than an arbitrary one:
+
+* **Flow control** runs first and is a *builtin*. Capacity rejection
+  (`maxBytes` / `maxRequests`), TTL eviction, and priority-band traversal are
+  infrastructure that protects the gateway process itself, so they are not
+  swappable. Priority-band selection is, in their words, "hardcoded and not
+  pluggable," and the queue contract states that "capacity management occurs
+  outside the queue implementation." Only the *signal* (`SaturationDetector`), the
+  *curve* (`UsageLimitPolicy`), and the *order* (`FairnessPolicy`,
+  `OrderingPolicy`) are plugins.
+* **`Admitter` plugins** run after `DataProducer` and before scheduling, and these
+  *can* reject outright. `latency-slo-admitter` ships in-tree.
+
+The load-shedding plugin proposed here is the `Admitter`: same pipeline position,
+same ordering relative to data preparation, same ability to reject. That
+correspondence is the reason the seam sits where it does.
+
+Excluding the flow-control layer (see Non Goals) is therefore not in tension with
+making shedding pluggable — upstream does not make that layer pluggable either.
+Dynamo's existing generic sheds are the local equivalent of it and stay as they
+are: the per-class caps enforced by `queue_rejection()` in `policy_queue.rs`, the
+EPP's in-flight semaphore (`DYN_EPP_MAX_INFLIGHT_REQUESTS`), and the worker engine
+request limit.
+
+The upstream split between the saturation *signal* and the admit/reject *decision*
+is a refinement this DEP does not currently make — it proposes one plugin that
+does both. Whether to split them is worth settling alongside REQ 1, since making
+the signal itself the seam would turn "one source of truth for overload" from a
+convention into a structural property.
 
 ## What becomes pluggable, and what does not
 
@@ -408,6 +442,11 @@ lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 * Over-engineered for current needs. The two plugins plus the shared state view cover
   the real use cases (custom tokenizer, custom overload policy). Additional
   extension points can be proposed later if a concrete need appears.
+* The gap is also narrower than it looks. `DataProducer` and `Admitter` are the only
+  two plugin points llm-d places between request parsing and scheduling, so this
+  proposal already matches upstream over that span. What Alt 1 adds beyond it is the
+  flow-control machinery and pluggable scoring — both already Non Goals, and the
+  former not pluggable upstream either.
 
 ## Alt 2 Keep load shedding / tokenization out of the EPP (gateway-level only)
 

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -165,10 +165,8 @@ Today the shed decision is funtion_of(worker_state). The client wants function_o
 
 
 The router side already has some of the machinery in the KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket — that is, bucketed on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length.
-But it drives queueing, and the shed path never calls it. They're also in different crates: classification in dynamo-kv-router, shed threshold in dynamo-llm's monitor.
-
-
-The classifier itself is reusable and implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, and the EPP cannot know those at shed time. Overlap comes from the KV index query inside `pick()`, whereas the shed gate runs before the body is even decoded. 
+But it drives queueing, and the shed path never calls it. They're also in different crates: classification in dynamo-kv-router, shed threshold in dynamo-llm's monitor. We need to use the classifier from it. 
+The classifier itself is implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, and the EPP cannot know those at shed time. Overlap comes from the KV index query inside `pick()`, whereas the shed gate runs before the body is even decoded. 
 
 ```bash
 pub fn resolve_class_index(&self, requested: Option<&str>, uncached_tokens: usize) -> usize {
@@ -181,21 +179,32 @@ pub fn resolve_class_index(&self, requested: Option<&str>, uncached_tokens: usiz
     }
 }
 ```
+We can run this alg before we select the worker and feed the tokens from the prompt into uncached_tokens BUT this would result in making the shedding worse. Raw ISL would systematically over-estimate cost on that traffic, so a mostly-cached large request would land in the "oversized" bucket and get shed — the precise issue we want to prevent.
 
-So this requirement resolves into one of three options, which differ in cost and in whether the
-router changes at all:
+This complication forces use to move the class - aware shedding after the workers are picked. This incurs additional overhead for a request we can potentially drop but this preserves our routing semantics. 
+The route_decode() function returns the returns overlap_blocks we need for the `resolve_class_index`. The signature is `Result<(WorkerWithDpRank, overlap_blocks)>`. We can then run
+```bash
+let (decode_worker, overlap_blocks) = self.route_decode(/* ... */).await?;
 
-1. **Classify on raw token count in the EPP.** No router change. The EPP keeps its own
-   per-class threshold table and buckets on prompt length. Cheapest, but the EPP's
-   class for a request then disagrees with the router's, so one request can be a
-   "small" shed class and a "large" queue class at the same time — the two-sources-of-
-   truth problem this DEP objects to elsewhere, in a new place.
-2. **Move the shed gate after tokenization.** We can feed raw prompt tokens as the size proxy to uncached_isl_buckets. But this would be counter-productive for the purpose. Raw ISL would systematically over-estimate cost on that traffic, so a mostly-cached large request would land in the "oversized" bucket and get shed — the precise mis-classification his design exists to prevent.
-3. **Move the gate after overlap sampling**. We will use true uncached ISL but have to run the query `find_matches on the indexer`. We will pay with time for the index query on a request we may to reject. But this extra cost is minor compared to the cost of tokenization. 
-4. **Push the decision into the router**, where uncached tokens and class assignment
-   already sit together. This is the only option requiring a router contract change:
-   `AdmissionDecision` is `Bypass | Ready | Defer` today, with no rejection variant, so
-   the policy-class admission API can hold a request indefinitely but cannot shed one.
+let cached_tokens =
+    overlap_blocks as usize * self.decode_router.block_size() as usize;
+let uncached_tokens = tokens.len().saturating_sub(cached_tokens);
+```
+
+The following flow is proposed:
+Router::pick()                          epp.rs   — general method in EPP
+ ├─ GATE A                              epp.rs   — This is basic shedding implemented in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865). This is not a plugin 
+ ├─ tokenize
+ ├─ Router::route_prefill()             epp.rs   — thin wrapper, no change
+ │    └─ PrefillRouter::…                        — kv-router, no change
+ ├─ Router::route_decode()              epp.rs   — thin wrapper, no change
+ │    └─ KvRouter::find_best_match()             — kv-router, no change
+ │         returns (worker, overlap_blocks)
+ ├─ GATE B                              epp.rs   — This will be a plugin for the new Class-Aware shedding  per customer request
+ ├─ resolve the worker endpoint
+ └─ Router::add_request()               epp.rs   — existing router book keeping
+      └─ KvRouter::add_request()                 — kv-router, no change
+
 
 The per-class thresholds should be configured in the router's policy YAML — which already carries a
 per-class `admission:` envelope rather than in EPP environment variables, since

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -218,6 +218,12 @@ Only a policy that actually wants uncached ISL pays for a second query, and it p
 knowingly. Moving the gate after the scheduler instead would impose the reordering on
 every deployment, whether or not it used a class-aware policy.
 
+Alt 4 proposes the opposite arrangement — placing the class-aware shed inside the router,
+where classification already sees accurate uncached ISL — which would remove the need for
+the advisory query and for a gateway-side Admitter altogether. It is open rather than
+rejected, and the choice between it and the arrangement below should be made before
+implementation starts.
+
 The following flow is proposed. `Router::pick()` is the `EndpointPicker` trait method in
 `epp.rs`; everything below it runs inside that call.
 
@@ -404,20 +410,6 @@ REQ 2: only the second case should become 429 with `Retry-After`. The first is a
 permanent failure, and attaching a retry hint to it actively misleads the gateway's
 failover logic. A policy that cannot see both sets cannot tell the two apart.
 
-### What keeps this from becoming a scoring API which we do not want to change
-
-Exposing state is not the same as making selection pluggable, which stays a Non Goal.
-Three properties hold that line:
-
-* **Read-only.** A plugin observes. It cannot mark a worker overloaded, retune a
-  threshold, or touch the KV index, so it has no way to steer selection through the
-  state view.
-* **A snapshot, not a live handle.** One frozen picture per decision, so two reads
-  within a single decision agree and there is nothing to poll in a loop. It is also
-  cheap to pass: a refcount bump rather than a map traversal.
-* **Typed and narrow.** Named accessors for signals we already maintain, not a
-  `HashMap<String, Value>`. Adding a fact becomes a reviewable code change instead of
-  a plugin quietly depending on a key nobody knew existed.
 
 ## Relationship to the router's policy-class admission API
 
@@ -577,3 +569,76 @@ router and subscribe to worker events independently.
 * This is effectively the status quo with extra ceremony. If the seam ships without
   the input the policy needs, integrators keep forking and we still own the
   compatibility burden of a published trait.
+
+## Alt 4 Implement class-aware shedding in the KV router; make the EPP a thin wrapper
+
+Put the shed decision where classification already happens — inside `dynamo-kv-router`'s
+scheduling path — instead of adding an Admitter plugin at the gateway. The EPP then
+contributes only the parts that are genuinely HTTP-shaped: an overload signal, a mapping
+from request headers to `policy_class`, and the translation of a rejection into 429 with
+`Retry-After`. 
+
+Most of the machinery for this already exists:
+
+| Piece | State |
+|-------|-------|
+| Class = family × uncached-ISL bucket | Exists (`FamilyBucketClassifier`) |
+| Per-class configuration envelope | Exists (`PolicyClassConfig`) |
+| Per-class rejection with a typed reason | Exists (`QueueRejection` → `KvSchedulerError::QueueRejected`) |
+| Reject when all eligible workers are overloaded | Exists (`KvSchedulerError::AllEligibleWorkersOverloaded`) |
+| Host-supplied overload signal | Exists (`OverloadedWorkerProvider`) |
+| Overload signal keyed *by class* | Missing |
+| EPP supplying any overload signal | Missing |
+
+The router will get a shedding policy plugin:
+
+```bash
+if let Some(policy) = &self.shed_policy {
+    match policy.evaluate(&ShedContext { class, uncached_tokens, eligibility, load }) {
+        ShedDecision::Reject { retry_after } => {
+            request.respond(Err(KvSchedulerError::Shed { policy_class: class.name.clone(), retry_after }));
+            return (false, false);
+        }
+        ShedDecision::Continue => {}
+    }
+}
+```
+
+The router therefore already rejects, and already rejects per class — the gap is narrower
+than "it queues instead of rejecting." `OverloadedWorkerProvider` is
+`Arc<dyn Fn() -> Option<HashSet<WorkerId>>>`; a closure taking no arguments can answer
+"who is overloaded" but never "who is overloaded *for this class*." Passing the class and
+its uncached token count is the core change.
+
+**Pros:**
+
+* Classification runs where `uncached_tokens` is already correct, after overlap is known.
+  This removes the need for the advisory query, the class-index derivation in the EPP, and
+  any question about where the gate sits relative to the scheduler — REQ 3's whole
+  complication disappears.
+* The frontend inherits the same capability from the same code, so 529-vs-429 becomes a
+  presentation choice for EPP vs the FrontEnd rather than two implementations of one policy.
+* Per-class thresholds live beside the per-class definitions in the router policy YAML,
+  which is where this DEP already argues they belong.
+* Queue-versus-reject behavior switch needed. We need two levels of configuration.
+ 1. Per class, in the policy YAML. A field on PolicyClassConfig next to the thresholds it already holds — on_saturation: Queue | Reject, defaulting to Queue so no Frontend deployment changes.The client wants the oversized-retry class rejects while the small-first-attempt class keeps queueing.
+ 2. We need a way to say reject-instead-of-queue in a form of a policy config. The EPP cannot defer requests because it runs inside an ext_proc callout with a timeout budget, where parking a request burns that budget and then likely times out anyway. The Frontend leaves it off because it owns the stream and can legitimately hold. Today you cannot ask for a class-aware shed threshold without also asking for deferral. 
+
+**Cons:**
+
+* Shedding stops being a gateway-level plugin. A user-supplied policy becomes a router
+  admission policy registered at a composition root, which is a different authoring
+  model from the one the rest of this DEP describes.
+* The shed necessarily happens after tokenization and the index query, so a rejected
+  request has already paid for both. Gate A still bounds that cost for the fully
+  saturated case.
+
+**Open — not yet rejected.** 
+
+There is also a coordination risk. `lib/kv-router/src/scheduling/queue_admission/` is
+described as the established boundary for policy-class admission algorithms, but the
+module currently contains only `RequestProgress` and `WorkerPlacement` — the contract is
+designed and unbuilt, and its decision set is `Bypass` / `Ready` / `Defer` with no
+`Reject`. Alt 4 amounts to adding `Reject` to that contract, so it likely belongs folded
+into whichever proposal owns it rather than pursued from the EPP side. Identify that
+owner before choosing between Alt 4 and the main proposal.

--- a/deps/0000-rust-epp-extensibility.md
+++ b/deps/0000-rust-epp-extensibility.md
@@ -37,9 +37,7 @@ previously only existed in Go.
 This proposal adds a minimal extension model to the Rust EPP: **two plugin types and
 one shared input**. The plugins are **DataProducer** (per-request data preparation before
 scheduling; tokenization is the first use) and **Admitter (load shedding)** (reject
-a request under overload). The Admitter runs after the scheduler has picked a worker and
-before the request is booked; "Why the Admitter runs after the scheduler" below explains
-why it sits there rather than in front of the scheduler as llm-d does.
+a request under overload before scheduling). 
 
 All plugins will need to have read-only worker-state view (the KV and prefill load signal)
 The worker-state view is a critical addition. A shedding policy that cannot
@@ -162,7 +160,7 @@ Today the shed decision is funtion_of(worker_state). The client wants function_o
 
 The router side already has some of the machinery. The KV router already assigns a request to a class either by explicit name or by an uncached ISL bucket, bucketing on the tokens that actually need prefilling, which is a better cost proxy than raw prompt length.
 But it drives queueing, and the shed path never calls it. They're also in different crates: classification in dynamo-kv-router, shed threshold in dynamo-llm's monitor. We need to use the classifier from the kv router. 
-The classifier itself is implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, and the EPP cannot know those at shed time. Overlap comes from the KV index query inside `pick()`, whereas the shed gate runs before the body is even decoded. 
+The classifier itself is implemented in `PolicyProfile::resolve_class_index`. The complication is its argument: it takes *uncached* tokens, which cannot be derived from the request alone. Overlap is a property of the prompt's block hashes walked against the KV index, not a property of worker state, so no amount of background monitoring produces it — the index has to be queried for this specific prompt. Today that query happens inside the routing call, whereas Gate A runs before the body is even decoded. 
 
 ```bash
 pub fn resolve_class_index(&self, requested: Option<&str>, uncached_tokens: usize) -> usize {
@@ -177,15 +175,48 @@ pub fn resolve_class_index(&self, requested: Option<&str>, uncached_tokens: usiz
 ```
 We can run this alg before we select the worker and feed the tokens from the prompt into uncached_tokens BUT this would result in making the shedding worse. Raw ISL would systematically over-estimate cost on that traffic, so a mostly-cached large request would land in the "oversized" bucket and get shed — the precise issue we want to prevent.
 
-This complication forces use to move the class-aware shedding logic after the workers are picked. This incurs additional overhead for a request we can potentially drop but this preserves our routing semantics. 
-The route_decode() function returns the returns overlap_blocks we need for the `resolve_class_index`. The signature is `Result<(WorkerWithDpRank, overlap_blocks)>`. We can then run
-```bash
-let (decode_worker, overlap_blocks) = self.route_decode(/* ... */).await?;
+The way out is that the router already exposes a routing query that books nothing.
+`KvRouter::find_best_match_details_without_admission` runs the normal route in
+`ScheduleMode::QueryOnly` and returns the facts a cost model needs — `cached_tokens` among
+them — without reserving anything:
 
-let cached_tokens =
-    overlap_blocks as usize * self.decode_router.block_size() as usize;
-let uncached_tokens = tokens.len().saturating_sub(cached_tokens);
+```rust
+pub enum FindBestMatchAdvisoryOutcome {
+    Routed {
+        worker: WorkerWithDpRank,
+        overlap_blocks: u32,
+        effective_overlap_blocks: f64,
+        cached_tokens: usize,
+        potential_decode_blocks: u64,
+        selected_worker_load: scheduling::AdvisoryWorkerLoad,
+        routing_hashes: Option<RoutingDecisionHashes>,
+    },
+    QueueRejected { rejection: scheduling::QueueRejection },
+}
 ```
+
+Because `cached_tokens` comes back directly, deriving the class index needs no block-size
+arithmetic:
+
+```rust
+let uncached_tokens = tokens.len().saturating_sub(cached_tokens);
+let class_index = profile.resolve_class_index(policy_class.as_deref(), uncached_tokens);
+```
+
+Conditional disaggregation already uses this path in exactly this shape: it calls the
+advisory query, reads `cached_tokens` and `selected_worker_load`, then calls
+`selected_worker_load.prefill_load_exceeds(threshold)` to decide whether to bypass prefill
+(`lib/llm/src/kv_router/prefill_router/conditional_bypass.rs`). A class-aware shed is the
+same decision shape, so this is an existing mechanism rather than a new one.
+
+**Performing the advisory query is the plugin's responsibility, not the pipeline's.** The
+Admitter therefore stays where llm-d puts it — after data preparation, before the
+scheduler — and a policy that needs overlap-derived facts issues the advisory query
+itself. That makes the cost opt-in. A deployment running no Admitter, or one whose policy
+keys only on worker state and request headers, routes exactly once and pays nothing extra.
+Only a policy that actually wants uncached ISL pays for a second query, and it pays
+knowingly. Moving the gate after the scheduler instead would impose the reordering on
+every deployment, whether or not it used a class-aware policy.
 
 The following flow is proposed. `Router::pick()` is the `EndpointPicker` trait method in
 `epp.rs`; everything below it runs inside that call.
@@ -194,12 +225,14 @@ The following flow is proposed. `Router::pick()` is the `EndpointPicker` trait m
 Router::pick()                             epp.rs
  ├─ GATE A request-blind shedding          epp.rs      (1)
  ├─ tokenize                               epp.rs
+ ├─ GATE B request-aware shedding          epp.rs      (2)  ← new, pluggable
+ │    └─ advisory query — only if the policy needs uncached ISL
+ │         └─ KvRouter::find_best_match_details_without_admission()
+ │                                         kv-router    existing, books nothing
  ├─ Router::route_prefill()                epp.rs       thin wrapper
  │    └─ PrefillRouter::…                  kv-router    unchanged
  ├─ Router::route_decode()                 epp.rs       thin wrapper
  │    └─ KvRouter::find_best_match()       kv-router    unchanged
- │         → (worker, overlap_blocks)
- ├─ GATE B request-aware shedding          epp.rs      (2)  ← new
  ├─ resolve the worker endpoint            epp.rs
  └─ Router::add_request()                  epp.rs       bookkeeping
       └─ KvRouter::add_request()           kv-router    unchanged
@@ -208,9 +241,12 @@ Router::pick()                             epp.rs
 1. **GATE A** — basic, request-blind shedding, already implemented in
    [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865). Not a plugin. It runs
    before tokenization, so it costs nothing to refuse a fully saturated pool. Every worker is continuously marked overloaded-or-not based on how full its KV cache and prefill queue are versus a fixed threshold, and Gate A rejects the incoming request with 429 only when every worker eligible to serve it is currently marked overloaded. Dynamo's frontend already sheds load (HTTP 529); the GAIE path needs the same, made extensible. The frontend's shed is a routing failure surfaced as an error, discovered after the request has already been parsed and tokenized. But customers pressing on explicit rejection versus implicit shed. The frontend returns 529 (configurable via DYN_HTTP_OVERLOAD_STATUS_CODE) with no retry hint. The EPP will return 429 with Retry-After. Both choices are intentional: 429 is what a gateway and its failover logic already understand, and the retry hint is new capability rather than parity. The beginning of its implementation is in [dynamo#11865](https://github.com/ai-dynamo/dynamo/pull/11865), which reuses the frontend's `KvWorkerMonitor` and adds a `PickError::Saturated { retry_after_secs }` variant surfaced as HTTP 429 with `Retry-After`. What remains is the wiring for the plugin. Caveat: One frontend capability also does not carry over: `POST`/`GET /busy_threshold` returns thresholds per model on a live fleet, whereas the EPP reads env vars once at startup. Closing that is out of scope here.
-2. **GATE B** — the new class-aware shedding, exposed as a plugin. It sits after
-   selection so it can derive uncached ISL from `overlap_blocks`, and before
-   `add_request`, so nothing is booked yet and a rejection needs no rollback.
+2. **GATE B** — the new class-aware shedding, exposed as a plugin, occupying the Admitter
+   position: after tokenization, before the scheduler. It rejects before anything is
+   booked, so a rejection has nothing to roll back — the advisory query reserves no
+   capacity even when a policy chooses to issue one. A policy that needs uncached
+   ISL obtains it from the advisory query; a policy keying only on worker state and
+   headers skips that call entirely.
 
 Everything marked `unchanged` is `dynamo-kv-router` code this proposal does not touch:
 scoring, selection, and the router's own bookkeeping all stay as they are.
@@ -226,17 +262,16 @@ This DEP does not pick one yet; the choice should be made before implementation 
 
 ## Overview
 
-Keep the existing request flow and insert two plugin points around the existing
-scheduler — data preparation in front of it, admission behind it — both reading one
-shared worker-state view:
+Keep the existing request flow and insert two plugin points in front of the existing
+scheduler, both reading one shared worker-state view:
 
 ```text
 ext_proc request
   → parse body / build request            built in
   → GATE A: global saturation shed        built in    request-blind, dynamo#11865
   → DataProducer plugin                   pluggable   tokenization lives here    [view]
-  → Scheduler: pick worker                built in    existing KV router, unchanged
   → GATE B: Admitter (load shedding)      pluggable   reject under overload      [view]
+  → Scheduler: pick worker                built in    existing KV router, unchanged
   → book the request + attach headers     built in
   → return decision to Envoy
   → response callbacks                    built in    prefill complete, usage
@@ -244,9 +279,9 @@ ext_proc request
 [view] = reads the shared read-only worker-state view
 ```
 
-This takes the useful part of the llm-d / GAIE flow — a data-preparation stage and a
-separate stage that may reject — without the surrounding machinery. For reference,
-llm-d's own ordering is:
+This matches the useful part of the llm-d / GAIE flow — a data-preparation stage, then a
+stage that may reject, then scheduling — without the surrounding machinery. llm-d's own
+ordering is:
 
 ```text
 Parse body → Build LLMRequest → Flow control   ← builtin, not pluggable
@@ -271,29 +306,18 @@ llm-d admits in two distinct places:
 * **`Admitter` plugins** run after `DataProducer` and before scheduling, and these
   *can* reject outright. The `latency-slo-admitter`plugin is an example here.
 
-The load-shedding plugin proposed here is that `Admitter`: same ability to reject
-outright, same read-only view of saturation, same ordering relative to data
-preparation. It diverges upstream in one respect — it runs *after* the scheduler rather
-than in front of it.
+The load-shedding plugin proposed here is that `Admitter`: same pipeline position, same
+ordering relative to data preparation, same ability to reject. That correspondence is the
+reason the seam sits where it does.
 
-### Why the Admitter runs after the scheduler
-
-Dynamo's cost proxy for a request is uncached ISL: the prompt tokens that actually need
-prefilling. That number is derived from `overlap_blocks`, which does not exist until
-`KvRouter::find_best_match()` has consulted the prefix index. Admitting in front of the
-scheduler would see raw prompt length only, and raw length mis-prices exactly the
-requests a class-aware policy cares about — a 100k-token prompt that is 95% cached is
-cheap, while an 8k-token prompt that is entirely uncached is not. Getting overlap earlier
-would mean either a second prefix-index query or reordering the router, and leaving
-`dynamo-kv-router` untouched is a constraint of this proposal. The gate therefore sits
-after selection and before `Router::add_request()`, where nothing has been booked yet, so
-a rejection needs no rollback.
-
-Deciding late costs something: a rejected request has already paid tokenization and the
-index query. Gate A bounds that cost. When every eligible worker is saturated the
-built-in shed refuses before any of that work happens, so the late gate only pays on
-requests that had a plausible home. llm-d can admit earlier because its
-`latency-slo-admitter` does not consult prefix overlap.
+One difference in the *policies* is worth noting, because it explains why this DEP needs a
+mechanism upstream does not. llm-d's `latency-slo-admitter` keys on facts that arrive with
+the request — SLO class and priority — plus a fleet-level saturation signal, so every
+input is available at ingress. Dynamo's class is derived partly from request *cost*, and
+the honest cost measure is uncached ISL, which requires querying the KV index for that
+specific prompt. Keeping the Admitter at the same pipeline position while still supporting
+a cost-derived class is what the advisory query above buys: the plugin reaches for overlap
+when its policy needs it, rather than the pipeline reordering itself for every deployment.
 
 
 The upstream split between the saturation *signal* and the admit/reject *decision*
@@ -308,15 +332,15 @@ does both. This is TBD.
 | Parse body / build request | No | Stable, shared parsing |
 | Global saturation shed (Gate A) | No | Process self-protection; fixed threshold, already built in |
 | DataProducer (tokenization) | Yes | Users need different tokenizers; enables prefix-cache routing and tokens-in forwarding |
-| Scheduler (worker pick) | No (for now) | The existing KV-aware router stays the default; can be revisited later |
 | Admitter (load shedding, Gate B) | Yes | Users need their own overload policy |
 | Worker-state view | No — read-only input | Not a stage. One shared source of truth for the signals policies need (REQ 1) |
+| Scheduler (worker pick) | No (for now) | The existing KV-aware router stays the default; can be revisited later |
 | Bookkeeping / headers | No | Internal correctness |
 
 The Rust EPP is currently `ext_proc` + scheduler; this proposal adds exactly two
-pluggable stages around the scheduler — data preparation in front of it, admission
-behind it — plus one read-only input feeding both, and leaves the scheduler itself built
-in. We are not making parsing, scoring, or picking pluggable at this time.
+pluggable stages in front of the scheduler, one read-only input feeding them, and leaves
+the scheduler built in. We are not making parsing, scoring, or picking pluggable at this
+time.
 
 ## How the plugins work (conceptually)
 
@@ -326,13 +350,13 @@ in. We are not making parsing, scoring, or picking pluggable at this time.
   default PrepareData plugin. If token data is already present (e.g. a pre-tokenized
   request), the plugin is skipped. PrepareData is fail-open: if a plugin errors, the
   request still proceeds and scheduling falls back to prompt-based behavior.
-* The scheduler then runs unchanged, consuming the token data that DataProducer produced
-  and yielding a selected worker together with its `overlap_blocks`.
-* **Admitter (Load-shedding)** plugins run last and default to allow: each plugin may reject
+* **Admitter (Load-shedding)** plugins run next and default to allow: each plugin may reject
   (mapped to HTTP 429 / 503, with 529 available for Dynamo clients); if none
   reject, the request proceeds. Multiple plugins can be chained and any rejection
-  stops the request. Because the gate precedes `Router::add_request()`, a rejection
-  leaves no booking to undo.
+  stops the request. A plugin whose policy needs request cost issues the advisory routing
+  query itself; that cost falls on the policies that want it rather than on every request.
+* The scheduler then runs unchanged, consuming the token data that DataProducer
+  produced.
 * We should also reconsider how to do priority scheduling to decide if we want to align with GAIE. See related [proposal](https://github.com/ai-dynamo/enhancements/pull/90)
 
 ## Worker state as a first-class input
@@ -502,11 +526,11 @@ lands second will need a small merge resolution in `picker.rs` and `epp.rs`.
 * Over-engineered for current needs. The two plugins plus the shared state view cover
   the real use cases (custom tokenizer, custom overload policy). Additional
   extension points can be proposed later if a concrete need appears.
-* The gap is also narrower than it looks. `DataProducer` and `Admitter` are the only two
-  plugin points llm-d exposes anywhere around scheduling, and this proposal adopts both —
-  differing only in where the `Admitter` sits relative to the scheduler, for the reason
-  given above. What Alt 1 adds beyond that is the flow-control machinery and pluggable
-  scoring — both already Non Goals, and the former not pluggable upstream either.
+* The gap is also narrower than it looks. `DataProducer` and `Admitter` are the only
+  two plugin points llm-d places between request parsing and scheduling, so this
+  proposal already matches upstream over that span. What Alt 1 adds beyond it is the
+  flow-control machinery and pluggable scoring — both already Non Goals, and the
+  former not pluggable upstream either.
 
 ## Alt 2 Keep load shedding / tokenization out of the EPP (gateway-level only)
 


### PR DESCRIPTION
The Go EPP is being deprecated, and its plugin-based extensibility goes away with it. We need a pluggable framework in the Rust EPP

fixes [DYN-3687](https://linear.app/nvidia/issue/DYN-3687/extend-rust-epp-to-support-plugins)